### PR TITLE
Fix ellipsis ‘…’ in subtitle of About page

### DIFF
--- a/views/about.erb
+++ b/views/about.erb
@@ -1,7 +1,7 @@
 <div class="header-Outro">
   <div class="row content single-Col">
   <h1>About Neocities</h1>
-  <h3 class="subtitle">Your free web page is waiting.. once again.</h3>
+  <h3 class="subtitle">Your free web page is waiting&#8230; once again.</h3>
   </div>
 </div>
 


### PR DESCRIPTION
There were one too few periods. And I use a horizontal ellipsis character instead of three periods. It’s the character ‘…’, XML-encoded because I don’t know if the site supports Unicode.

Link to About page: https://neocities.org/about
