### PR TITLE
Make "Clouds" default text editor theme

### DIFF
--- a/views/site_files/text_editor.slim
+++ b/views/site_files/text_editor.slim
@@ -5,6 +5,7 @@ css:
       right: 0;
       bottom: 0;
       left: 0;
+      border: 1px solid rgb(232, 223, 207);
   }
   .theme-Code{
     float:right;
@@ -22,7 +23,7 @@ css:
       select id="theme" size="1" onchange="setTheme();" onkeyup="setTheme();"
         optgroup label="Bright"
           option value="ace/theme/chrome" Chrome
-          option value="ace/theme/clouds" Clouds
+          option value="ace/theme/clouds" selected="selected" Clouds
           option value="ace/theme/crimson_editor" Crimson Editor
           option value="ace/theme/dawn" Dawn
           option value="ace/theme/dreamweaver" Dreamweaver
@@ -44,7 +45,7 @@ css:
           option value="ace/theme/mono_industrial" Mono Industrial
           option value="ace/theme/monokai" Monokai
           option value="ace/theme/pastel_on_dark" Pastel on dark
-          option value="ace/theme/solarized_dark" selected="selected" Solarized Dark
+          option value="ace/theme/solarized_dark" Solarized Dark
           option value="ace/theme/terminal" Terminal
           option value="ace/theme/tomorrow_night" Tomorrow Night
           option value="ace/theme/tomorrow_night_blue" Tomorrow Night Blue


### PR DESCRIPTION
The default solarized theme is hard to read and very dark, making it somewhat imposing for beginners, which I've seen with my students. It also doesn't go very well with the rest of the Neocities UI.

As a designer, I would recommend changing the default theme to Clouds, which is what this pull request does, but frankly almost anything is better. I also added a subtle border around the editor in order to differentiate it from the rest of the page when a light theme is selected.
