### PR TITLE
Patch for adding CORS support

### DIFF
--- a/app/api.rb
+++ b/app/api.rb
@@ -7,6 +7,7 @@ end
 
 post '/api/upload' do
   require_api_credentials
+  cors_headers(current_site.domain)
 
   files = []
   params.each do |k,v|
@@ -43,6 +44,7 @@ end
 
 post '/api/delete' do
   require_api_credentials
+  cors_headers(current_site.domain)
 
   api_error 400, 'missing_filenames', 'you must provide files to delete' if params[:filenames].nil? || params[:filenames].empty?
 
@@ -111,11 +113,15 @@ post '/api/:name' do
 end
 
 options '/api/:name' do
-  response.headers["Access-Control-Allow-Origin"] = current_site.domain
+  cors_headers(current_site.domain)
+  halt 200  
+end
+
+def cors_headers(domain)
+  response.headers["Access-Control-Allow-Origin"] = domain
   response.headers["Access-Control-Allow-Methods"] = "GET,POST,OPTIONS"
   response.headers["Access-Control-Allow-Credentials"] = "true"
-  response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Authorization"
-  halt 200  
+  response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Authorization"  
 end
 
 def require_api_credentials
@@ -163,9 +169,6 @@ def api_success(message_or_obj)
 end
 
 def api_response(status, output)
-  response.headers["Access-Control-Allow-Origin"] = current_site.domain
-  response.headers["Access-Control-Allow-Credentials"] = "true"
-  response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Authorization"
   halt status, JSON.pretty_generate(output)+"\n"
 end
 

--- a/app/api.rb
+++ b/app/api.rb
@@ -110,6 +110,14 @@ post '/api/:name' do
   api_not_found
 end
 
+options '/api/:name' do
+	response.headers["Access-Control-Allow-Origin"] = current_site.domain
+	response.headers["Access-Control-Allow-Methods"] = "GET,POST,OPTIONS"
+	response.headers["Access-Control-Allow-Credentials"] = "true"
+	response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+	halt 200  
+end
+
 def require_api_credentials
   if !request.env['HTTP_AUTHORIZATION'].nil?
     init_api_credentials
@@ -155,6 +163,9 @@ def api_success(message_or_obj)
 end
 
 def api_response(status, output)
+  response.headers["Access-Control-Allow-Origin"] = current_site.domain
+	response.headers["Access-Control-Allow-Credentials"] = "true"
+	response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Authorization"
   halt status, JSON.pretty_generate(output)+"\n"
 end
 

--- a/app/api.rb
+++ b/app/api.rb
@@ -111,11 +111,11 @@ post '/api/:name' do
 end
 
 options '/api/:name' do
-	response.headers["Access-Control-Allow-Origin"] = current_site.domain
-	response.headers["Access-Control-Allow-Methods"] = "GET,POST,OPTIONS"
-	response.headers["Access-Control-Allow-Credentials"] = "true"
-	response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Authorization"
-	halt 200  
+  response.headers["Access-Control-Allow-Origin"] = current_site.domain
+  response.headers["Access-Control-Allow-Methods"] = "GET,POST,OPTIONS"
+  response.headers["Access-Control-Allow-Credentials"] = "true"
+  response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+  halt 200  
 end
 
 def require_api_credentials
@@ -164,8 +164,8 @@ end
 
 def api_response(status, output)
   response.headers["Access-Control-Allow-Origin"] = current_site.domain
-	response.headers["Access-Control-Allow-Credentials"] = "true"
-	response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+  response.headers["Access-Control-Allow-Credentials"] = "true"
+  response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Authorization"
   halt status, JSON.pretty_generate(output)+"\n"
 end
 


### PR DESCRIPTION
These changes should allow the API to be called using javascript in the site itself, which in turn would, for example, allow creating a website editor that runs in the browser itself with no further server side components. The header should only allow calls from the site itself to the neocities API.

Please note I'm not a ruby programmer, so this patch should be reviewed
