### PR TITLE
Accessibility description for img in template.

### DIFF
--- a/views/templates/index.erb
+++ b/views/templates/index.erb
@@ -16,7 +16,7 @@
     <p>Here's how you can make <strong>bold</strong> and <em>italic</em> text.</p>
 
     <p>Here's how you can add an image:</p>
-    <img src="/neocities.png">
+    <img src="/neocities.png" alt="cat with text 'hosted by Neocities'">
 
     <p>Here's how to make a list:</p>
 


### PR DESCRIPTION
As a tool for technology education, I think Neocities should model good accessibility practices by including an alt attribute on the img in the template. 
