### PR TITLE
Fixed browsing tiles leading to unintended pages

### DIFF
--- a/views/browse.erb
+++ b/views/browse.erb
@@ -81,8 +81,6 @@
            title="<%= site.title %>"
            <% if @surfmode %>
              onclick="surf(<%= ((@page-1)*Site::BROWSE_PAGINATION_LENGTH)+i+1 %>); return false"
-           <% else %>
-             href="<%= site.uri %>"
            <% end %>
         >
           <span class="img-Holder" style="background:url(<%= site.screenshot_url('index.html', '540x405') %>) no-repeat;">
@@ -90,7 +88,12 @@
           </span>
         </a>
         <div class="title">
-          <a href="<%= site.uri %>" title="<%= site.title %>" onclick="surf(<%= i+1 %>); return false"><%= site.title.shorten(30) %></a>
+          <a href="<%= site.uri %>"
+             title="<%= site.title %>"
+             <% if @surfmode %>
+               onclick="surf(<%= ((@page-1)*Site::BROWSE_PAGINATION_LENGTH)+i+1 %>); return false"
+             <% end %>
+          ><%= site.title.shorten(30) %></a>
         </div>
         <div class="site-info">
           <div class="username">


### PR DESCRIPTION
Fixed title ignoring surf mode state and leading to the wrong page if
the current page is >1
(And also removed double `href` attribute when surfmode isn't enabled)
