### PR TITLE
Change all Twitter links to @Neocities from @NeocitiesWeb

### DIFF
--- a/public/gateway_error.html
+++ b/public/gateway_error.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <h1>Neocities is temporarily unavailable</h1>
-    <p>Neocities is currently undergoing maintenance, we will be back shortly! Check <a href="https://twitter.com/neocitiesweb">@neocitiesweb</a> for status updates.</p>
+    <p>Neocities is currently undergoing maintenance, we will be back shortly! Check <a href="https://twitter.com/neocities">@neocities</a> for status updates.</p>
     <p>Our apologies for the inconvenience.</p>
   </body>
 </html>

--- a/views/_footer.erb
+++ b/views/_footer.erb
@@ -3,7 +3,7 @@
 
     <div class="row">
       <p class="tiny col credits">
-        <a href="http://neocities.org" title="Neocities.org" style="text-decoration:none;">Neocities</a> is <a href="https://github.com/neocities" title="Neocities on GitHub">open source</a>. Follow us on <a href="https://twitter.com/neocitiesweb">Twitter</a> or <a href="https://www.facebook.com/neocities">Facebook</a>
+        <a href="http://neocities.org" title="Neocities.org" style="text-decoration:none;">Neocities</a> is <a href="https://github.com/neocities" title="Neocities on GitHub">open source</a>. Follow us on <a href="https://twitter.com/neocities">Twitter</a> or <a href="https://www.facebook.com/neocities">Facebook</a>
       </p>
 
       <nav class="footer-Nav col">

--- a/views/_team.erb
+++ b/views/_team.erb
@@ -22,5 +22,5 @@
 
 <hr />
 <section>
-  <h2 class="txt-Center">Follow us on <a href="https://twitter.com/neocitiesweb">Twitter</a> or <a href="https://www.facebook.com/neocities">Facebook</a></h2>
+  <h2 class="txt-Center">Follow us on <a href="https://twitter.com/neocities">Twitter</a> or <a href="https://www.facebook.com/neocities">Facebook</a></h2>
 </section>

--- a/views/templates/email/supporter_upgrade.erb
+++ b/views/templates/email/supporter_upgrade.erb
@@ -4,7 +4,7 @@ A Neocities administrator has upgraded your account to supporter! We're looking 
 
 Thank you very, very much for supporting Neocities. It means a lot to us. We'll try our hardest to keep improving the site and stick to our core values (NO MARKETING OR ADVERTISING, EVER).
 
-If you have any questions or comments, or just want to say hi, feel free to contact us at https://neocities.org/contact. You can also reach us on Twitter at @neocitiesweb.
+If you have any questions or comments, or just want to say hi, feel free to contact us at https://neocities.org/contact. You can also reach us on Twitter at @neocities.
 
 From Penelope (the Neocities' cat/sysadmin), everyone that's helped work on Neocities, and on behalf of all our sites, our very best wishes for you (and your awesome web site).
 

--- a/views/templates/email_subscription.erb
+++ b/views/templates/email_subscription.erb
@@ -4,6 +4,6 @@ We're writing to confirm your upgrade to the <%= plan_name %> Plan. You now have
 
 Thank you very much for supporting Neocities. It allows us to continue offering our free plan to everyone who wants one and helps fund further development.
 
-If you have any questions or comments, or just want to say hi, feel free to contact us at https://neocities.org/contact. You can also reach us on Twitter at @neocitiesweb.
+If you have any questions or comments, or just want to say hi, feel free to contact us at https://neocities.org/contact. You can also reach us on Twitter at @neocities.
 
 — The Neocities Team

--- a/views/templates/email_welcome.erb
+++ b/views/templates/email_welcome.erb
@@ -6,7 +6,7 @@ Making your first (or your latest) web site is a powerful thing. Unlike traditio
 
 Since you're new, we've put together a basic "hello world" page for you. Now all you need to do is login and edit your "index.html" file, and you're on your way to being a webmaster of your own site on the World Wide Web!
 
-If you have any questions or comments, or just want to say hi, feel free to contact us at https://neocities.org/contact. You can also reach us on Twitter at @neocitiesweb. We're super busy, so we can't help you with everything, but if you have a problem or bug to report, we'll try our best to look into it.
+If you have any questions or comments, or just want to say hi, feel free to contact us at https://neocities.org/contact. You can also reach us on Twitter at @neocities. We're super busy, so we can't help you with everything, but if you have a problem or bug to report, we'll try our best to look into it.
 
 From Penelope (the Neocities cat), the Neocities Team, and on behalf of all our sites, our very best wishes for you (and your awesome web site). We can't wait to see what it looks like!
 


### PR DESCRIPTION
Neocities recently went from @NeocitiesWeb to @Neocities on Twitter, so Neocities.org should reflect that.