### PR TITLE
Remove Mention of Underscores in Signup Dialog

### DIFF
--- a/models/site.rb
+++ b/models/site.rb
@@ -943,7 +943,7 @@ class Site < Sequel::Model
     super
 
     if !self.class.valid_username?(values[:username])
-      errors.add :username, 'Usernames can only contain letters, numbers, underscores and hyphens.'
+      errors.add :username, 'Usernames can only contain letters, numbers, and hyphens.'
     end
 
     if !values[:username].blank?


### PR DESCRIPTION
Underscores are not allowed in usernames, so they shouldn't be mentioned as allowed.

Resubmitting this as the previous pull request was incorrect, apologies for that.