### PR TITLE
Added two little details to Vagrant environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ vagrant up --provision
 
 ```
 vagrant ssh
-cd /vagrant
 bundle exec rackup -o 0.0.0.0
 ```
 

--- a/vagrant/development.sh
+++ b/vagrant/development.sh
@@ -17,3 +17,16 @@ sudo sh -c 'echo "local all all trust" >> /etc/postgresql/9.3/main/pg_hba.conf'
 sudo sh -c 'echo "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.3/main/pg_hba.conf'
 sudo sh -c 'echo "host all all ::1/128 trust" >> /etc/postgresql/9.3/main/pg_hba.conf'
 sudo service postgresql restart
+
+# Create empty file for disposable email accounts
+DISPOSABLE_EMAIL_PATH=/vagrant/files/disposable_email_blacklist.conf
+if [ ! -f $DISPOSABLE_EMAIL_PATH ]; then
+    sudo su vagrant -c "touch $DISPOSABLE_EMAIL_PATH"
+fi
+
+# Automatically enter the project path on vagrant ssh
+if grep -qv "cd /vagrant" /home/vagrant/.bashrc
+then
+    sudo su vagrant -c "echo 'cd /vagrant' >> ~/.bashrc"
+fi
+


### PR DESCRIPTION
- `cd /vagrant` is done automatically now on login to the `vagrant` user.
- The `disposable_email_blacklist.conf` file is now generated automatically if it does not exist.
  This one I added it automatically because is a pain, but if you don't want it to create like this I will change the README to specify that this file needs to be created (rather to get an error on the first run and figuring out what's happening!).

![sparta](https://user-images.githubusercontent.com/812088/54157202-1f00f000-4448-11e9-8d60-a68c42c99d8b.jpeg)
