### PR TITLE
Ask for confirmation when user deletes comment

### DIFF
--- a/public/js/news/comment.js
+++ b/public/js/news/comment.js
@@ -9,9 +9,32 @@ var Comment = {
   },
 
   delete: function(commentId, csrfToken) {
-    $.post('/comment/'+commentId+'/delete', {csrf_token: csrfToken}, function(res) {
-      location.reload()
-    })
+    var link = $('#comment_'+commentId+'_delete')
+
+    if (link.hasClass('confirm')) {
+      // user confirms deletion, delete
+      $.post('/comment/'+commentId+'/delete', {csrf_token: csrfToken}, function(res) {
+          location.reload()
+      })
+    } else {
+      // first time user pressed delete, ask if they're sure
+      var parentEl = link.parent()
+
+      var spanEl = $('<span>Sure? </span>')
+
+      link.addClass('confirm').text('Delete').detach()
+      spanEl.append(link)
+
+      spanEl.append($('<a>Cancel</a>').on('click', function(evnt) {
+        var pEl = $(evnt.target.parentElement)
+        var el = pEl.children('a.confirm').removeClass('confirm').text('Delete').detach()
+        var ppEl = pEl.parent()
+        pEl.remove()
+        ppEl.append(el)
+      }))
+
+      parentEl.append(spanEl)
+    }
   },
 
   toggleLike: function(commentId, csrfToken) {

--- a/public/js/news/event.js
+++ b/public/js/news/event.js
@@ -1,7 +1,30 @@
 var Event = {
   delete: function(eventId, csrfToken) {
-    $.post('/event/'+eventId+'/delete', {csrf_token: csrfToken}, function(res) {
-      location.reload()
-    })
+    var link = $('#event_'+eventId+'_actions a.event_delete')
+
+    if (link.hasClass('confirm')) {
+      // user confirms deletion, delete
+      $.post('/event/'+eventId+'/delete', {csrf_token: csrfToken}, function(res) {
+          location.reload()
+      })
+    } else {
+      // first time user pressed delete, ask if they're sure
+      var parentEl = link.parent()
+
+      var spanEl = $('<span>Sure? </span>')
+
+      link.addClass('confirm').text('Delete').detach()
+      spanEl.append(link)
+
+      spanEl.append($('<a>Cancel</a>').on('click', function(evnt) {
+        var pEl = $(evnt.target.parentElement)
+        var el = pEl.children('a.confirm').removeClass('confirm').text('Delete').detach()
+        var ppEl = pEl.parent()
+        pEl.remove()
+        ppEl.append(el)
+      }))
+
+      parentEl.append(spanEl)
+    }
   }
 }

--- a/views/_news.erb
+++ b/views/_news.erb
@@ -166,7 +166,7 @@
 
             <% if current_site %>
               <% if event.site_id == current_site.id || comment.actioning_site_id == current_site.id %>
-                <a href="#" onclick="Comment.delete(<%= comment.id %>, '<%= csrf_token %>'); return false">Delete</a>
+                <a href="#" id="comment_<%= comment.id %>_delete" onclick="Comment.delete(<%= comment.id %>, '<%= csrf_token %>'); return false">Delete</a>
               <% end %>
             <% end %>
           </div>

--- a/views/_news_actions.erb
+++ b/views/_news_actions.erb
@@ -15,7 +15,7 @@
         <a id="editLink" href="#" onclick="ProfileComment.displayEditor('<%= event.id %>'); return false">Edit</a>
     <% end %>
     <% if event.created_by?(current_site) || event.site_id == current_site.id %>
-      <a href="#" onclick="Event.delete(<%= event.id %>, '<%= csrf_token %>'); return false">Delete</a>
+      <a href="#" class="event_delete" onclick="Event.delete(<%= event.id %>, '<%= csrf_token %>'); return false">Delete</a>
     <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
After numerous accidental deletions, I have programmed a confirmation message. [It looks like this.](https://joppiesaus.neocities.org/div/deletus-2019-09-14_21.02.53.mp4)
An improvement would be instead of a confirmation message something like "Deleted. Undo". For now the confirmation message solution should prevent some suffering.
Have a great day! :smile: