### PR TITLE
Included a procedure to install the rake gem, in case of a rake error

### DIFF
--- a/views/cli.erb
+++ b/views/cli.erb
@@ -28,6 +28,10 @@
 
     <code>sudo gem install neocities</code>
 
+    <p>If you get a rake error, you make need to install the rake gem as superuser <strong>before running the command above</strong>:</p>
+
+    <code>sudo gem install rake</code>
+
     <p>After installation, just run the command to get started:</p>
 
     <pre>$ neocities


### PR DESCRIPTION
I was getting a rake error when trying to do the `sudo gem install neocities`, so I included a procedure in the CLI documentation to install the rake gem, in case other users were having this problem.

I hope this helps!