### PR TITLE
Fix vagrant not working

### DIFF
--- a/vagrant/ruby.sh
+++ b/vagrant/ruby.sh
@@ -3,5 +3,5 @@
 apt-get -y install python-software-properties
 apt-add-repository -y ppa:brightbox/ruby-ng
 apt-get -y update
-apt-get -y install ruby2.4 ruby2.4-dev
+apt-get -y install ruby2.5 ruby2.5-dev
 gem install bundler --no-rdoc --no-ri


### PR DESCRIPTION
Some Gem required Ruby 2.5, so install that instead over 2.4.