### PR TITLE
Add xhtml to list of valid extensions

### DIFF
--- a/models/site.rb
+++ b/models/site.rb
@@ -10,6 +10,7 @@ class Site < Sequel::Model
   VALID_MIME_TYPES = %w{
     text/plain
     text/html
+    application/xhtml+xml
     text/css
     application/javascript
     image/png
@@ -43,11 +44,11 @@ class Site < Sequel::Model
   }
 
   VALID_EXTENSIONS = %w{
-    html htm txt text css js jpg jpeg png gif svg md markdown eot ttf woff woff2 json geojson csv tsv mf ico pdf asc key pgp xml mid midi manifest otf webapp less sass rss kml dae obj mtl scss webp xcf epub gltf bin webmanifest knowl atom opml rdf
+    html htm xhtml txt text css js jpg jpeg png gif svg md markdown eot ttf woff woff2 json geojson csv tsv mf ico pdf asc key pgp xml mid midi manifest otf webapp less sass rss kml dae obj mtl scss webp xcf epub gltf bin webmanifest knowl atom opml rdf
   }
 
   VALID_EDITABLE_EXTENSIONS = %w{
-    html htm txt js css scss md manifest less webmanifest xml json opml rdf
+    html htm xhtml txt js css scss md manifest less webmanifest xml json opml rdf
   }
 
   MINIMUM_PASSWORD_LENGTH = 5


### PR DESCRIPTION
This also adds the `application/xhtml+xml` mime type, which is recommended<sup>[1][2][3]</sup> and widely supported<sup>[4]</sup>, but not yet returned by magic/file<sup>[5][6]</sup> for `*.xhtml` files.

This means that `Site.valid_file_type?` does not need the mime type to be in the list, but should [libmagic/file](http://www.darwinsys.com/file/) ever adopt W3C's recommendation, Neocities will be ready for that.

[1] https://www.w3.org/International/articles/serving-xhtml/#mime
[2] https://www.w3.org/2003/01/xhtml-mimetype/
[3] https://www.w3.org/TR/xhtml-media-types/#media-types
[4] https://caniuse.com/xhtml
[5] https://github.com/qoobaa/magic/blob/a93a0fac5/lib/magic.rb#L36-L38
[6] https://github.com/file/file/blob/54393977c/magic/Magdir/sgml#L28-L40