### PR TITLE
Upgrade Vagrant to bionic (was trusty)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,12 +1,12 @@
 VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'ubuntu/trusty64'
+  config.vm.box = 'ubuntu/bionic64'
   config.vm.provision :shell, path: './vagrant/development.sh'
   config.vm.network :forwarded_port, guest: 9292, host: 9292
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ['modifyvm', :id, '--memory', '1536']
+    vb.customize ['modifyvm', :id, '--memory', '2048']
     vb.name = 'neocities'
   end
 end

--- a/vagrant/development.sh
+++ b/vagrant/development.sh
@@ -12,11 +12,11 @@ sudo su postgres -c "createuser -d vagrant"
 sudo su vagrant -c "createdb neocities"
 sudo su vagrant -c "createdb neocities_test"
 
-sudo sh -c 'echo "local all postgres trust" > /etc/postgresql/9.3/main/pg_hba.conf'
-sudo sh -c 'echo "local all all trust" >> /etc/postgresql/9.3/main/pg_hba.conf'
-sudo sh -c 'echo "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.3/main/pg_hba.conf'
-sudo sh -c 'echo "host all all ::1/128 trust" >> /etc/postgresql/9.3/main/pg_hba.conf'
-sudo service postgresql restart
+sudo sh -c 'echo "local all postgres trust" > /etc/postgresql/10/main/pg_hba.conf'
+sudo sh -c 'echo "local all all trust" >> /etc/postgresql/10/main/pg_hba.conf'
+sudo sh -c 'echo "host all all 127.0.0.1/32 trust" >> /etc/postgresql/10/main/pg_hba.conf'
+sudo sh -c 'echo "host all all ::1/128 trust" >> /etc/postgresql/10/main/pg_hba.conf'
+sudo systemctl restart postgresql
 
 # Create empty file for disposable email accounts
 DISPOSABLE_EMAIL_PATH=/vagrant/files/disposable_email_blacklist.conf

--- a/vagrant/ruby.sh
+++ b/vagrant/ruby.sh
@@ -3,5 +3,5 @@
 apt-get -y install python-software-properties
 apt-add-repository -y ppa:brightbox/ruby-ng
 apt-get -y update
-apt-get -y install ruby2.4 ruby2.4-dev
-gem install bundler --no-rdoc --no-ri
+apt-get -y install ruby2.6 ruby2.6-dev
+gem install bundler --no-document


### PR DESCRIPTION
In particular this fixes some Chrome test failures. The old version of Chromium available on Trusty was giving JavaScript errors.

RAM had to be increased too, because Git was running out of memory during provisioning.

Also upgrade to Ruby 2.6 to fix dependencies.

Skip Ubuntu 16.04 Xenial because it is close to end-of-life. For example being [removed from GitHub Actions](https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/) soon.