### PR TITLE
api: fix issue with /api/list "sha1_hash" fields being null when using "path" param

### DIFF
--- a/models/site.rb
+++ b/models/site.rb
@@ -1271,6 +1271,7 @@ class Site < Sequel::Model
       if site_file
         file[:size] = site_file.size unless file[:is_directory]
         file[:updated_at] = site_file.updated_at
+        file[:sha1_hash] = site_file.sha1_hash
       end
 
       file[:is_html] = !(extname.match(HTML_REGEX)).nil?

--- a/tests/api_tests.rb
+++ b/tests/api_tests.rb
@@ -63,13 +63,15 @@ describe 'api' do
       tempfile = Tempfile.new
       tempfile.write('meep html')
       @site.store_files [{filename: '/derp/test.html', tempfile: tempfile}]
+      site_file = @site.site_files.select {|s| s.path == 'derp/test.html'}.first
       basic_authorize @user, @pass
       get '/api/list', path: '/derp'
       res[:result].must_equal 'success'
       res[:files].length.must_equal 1
       file = res[:files].first
       file[:path].must_equal 'derp/test.html'
-      file[:updated_at].must_equal @site.site_files.select {|s| s.path == 'derp/test.html'}.first.updated_at.rfc2822
+      file[:updated_at].must_equal site_file.updated_at.rfc2822
+      file[:sha1_hash].must_equal site_file.sha1_hash
     end
   end
 


### PR DESCRIPTION
The "sha1_hash" field in file objects returned from the /api/list API endpoint, recommended in #252 and added with #295, work correctly when calling the endpoint without any path parameter. However, when a specific path is requested, the "sha1_hash" field is always null. This is due to `Site.site_files` being used directly when no path is present, which provides file objects with a correct "sha1_hash" field, but `Site.file_list` being used when a path is provided, which provides newly created file objects without a "sha1_hash" field. This pull request fixes this by making `Site.file_list` copy over the "sha1_hash" field from the original files from the `site_files_dataset`.

From a user's perspective, notice the difference between `https://neocities.org/api/list` and `https://neocities.org/api/list?path=/`:
![without_path](https://user-images.githubusercontent.com/7506308/147713604-e437c125-00ca-4d3f-8f24-109811d86cbd.png)
![with_path](https://user-images.githubusercontent.com/7506308/147713609-abea5911-c0a0-475e-8b0f-963d5a36294c.png)