### PR TITLE
docs(readme): use github fork link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Now you can access the running site from your browser: http://127.0.0.1:9292
 
 If you'd like to fix a bug, or make an improvement, or add a new feature, it's easy! Just send us a Pull Request.
 
-1. Fork it (<http://github.com/YOURUSERNAME/neocities/fork>)
+1. Fork it (https://github.com/neocities/neocities/fork)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
The fork button at the top of github is https://github.com/OWNER/REPO/fork. 

Using this link makes it slightly easier for newer contributors to do the right thing