### PR TITLE
Cleanup Tutorials page links

### DIFF
--- a/views/tutorials.erb
+++ b/views/tutorials.erb
@@ -17,19 +17,16 @@
 
   <ul>
     <li>
-      <a href="http://www.htmldog.com/guides/html/beginner" title="Learn beginner HTML">HTML Beginner Tutorial</a>
+      <a href="https://www.htmldog.com/guides/html/beginner" title="Learn beginner HTML">HTML Beginner Tutorial</a>
     </li>
     <li>
       <a href="https://developer.mozilla.org/en-US/learn/html" title="Learn beginner HTML from Mozilla">Mozilla Learn HTML Resources</a>
     </li>
     <li>
-      <a href="http://codepupil.com/" title="Learn from games">CodePupil.com teaches with games</a>
+      <a href="https://teamtreehouse.com">Learn how to build websites with Treehouse</a>
     </li>
     <li>
-      <a href="http://teamtreehouse.com">Learn how to build websites with Treehouse</a>
-    </li>
-    <li>
-      <a href="http://www.codecademy.com/tracks/web" title="online lessons">Online lessons at Codecademy</a>
+      <a href="https://www.codecademy.com/tracks/web" title="online lessons">Online lessons at Codecademy</a>
     </li>
   </ul>
 


### PR DESCRIPTION
Fixes #419 I guess.

Note that we might want to also remove TeamTreehouse and change the link for Codecademy,
[as I commented at that issue](https://github.com/neocities/neocities/issues/419#issuecomment-1417701083),
as TeamTreehouse requires a credit card for a 7 day free trial, and the codecademy Web Development Catalog includes a lot of overwhelming backend courses (we can link directly to the HTML course instead)
