### PR TITLE
Remove dead social networks from share button

### DIFF
--- a/views/_share.erb
+++ b/views/_share.erb
@@ -12,3 +12,4 @@
 <a href="https://www.reddit.com/submit?<%= Rack::Utils.build_query(title: "#{site.title}", url: "#{page_uri}" )%>" target="_blank">Reddit</a>
 <br>
 <a href="https://www.tumblr.com/share?<%= Rack::Utils.build_query(v: 3, u: "#{page_uri}", t: "#{site.title}") %>" target="_blank">Tumblr</a>
+<a href="https://toot.kytta.dev/?text=<%= Rack::Utils.build_query(u: "#{page_uri}") %>" target="_blank">Mastodon</a>

--- a/views/_share.erb
+++ b/views/_share.erb
@@ -12,9 +12,3 @@
 <a href="https://www.reddit.com/submit?<%= Rack::Utils.build_query(title: "#{site.title}", url: "#{page_uri}" )%>" target="_blank">Reddit</a>
 <br>
 <a href="https://www.tumblr.com/share?<%= Rack::Utils.build_query(v: 3, u: "#{page_uri}", t: "#{site.title}") %>" target="_blank">Tumblr</a>
-<br>
-<a href="https://www.stumbleupon.com/submit?<%= Rack::Utils.build_query(url: "#{page_uri}", title: "#{site.title}") %>" target="_blank">StumbleUpon</a>
-<br>
-<a href="https://del.icio.us/post?<%= Rack::Utils.build_query(url: "#{page_uri}", title: "#{site.title}") %>" target="_blank">Del.ici.ous</a>
-<br>
-<a href="https://plus.google.com/share?<%= Rack::Utils.build_query(url: "#{page_uri}") %>" target="_blank">Google+</a>


### PR DESCRIPTION
They are all very dead & show no signs of returning any time soon, sadly.