### PR TITLE
remove typo line

### DIFF
--- a/views/_news.erb
+++ b/views/_news.erb
@@ -58,7 +58,6 @@
             <% end %>
 
             sent a <strong><%= tip.amount_string %></strong> tip to
-site/actioning_site.username
             <% if current_site && event_site.id == current_site.id %>
               <a href="/site/<%= current_site.username %>" class="you">you</a>!
             <% else %>


### PR DESCRIPTION
It seems like "site/actioning_site.username" was added by accident, as it is not in a formatted string, its just there in plaintext. This was causing some issues with donations/tips displaying. You can view an example of this here:
https://neocities.org/site/errormine?event_id=2722293