### PR TITLE
Fix Mastodon Share

### DIFF
--- a/views/_share.erb
+++ b/views/_share.erb
@@ -12,4 +12,5 @@
 <a href="https://www.reddit.com/submit?<%= Rack::Utils.build_query(title: "#{site.title}", url: "#{page_uri}" )%>" target="_blank">Reddit</a>
 <br>
 <a href="https://www.tumblr.com/share?<%= Rack::Utils.build_query(v: 3, u: "#{page_uri}", t: "#{site.title}") %>" target="_blank">Tumblr</a>
-<a href="https://toot.kytta.dev/?text=<%= Rack::Utils.build_query(u: "#{page_uri}") %>" target="_blank">Mastodon</a>
+<br>
+<a href="https://toot.kytta.dev/?<%= Rack::Utils.build_query(text: "#{site.title}: #{page_uri}") %>" target="_blank">Mastodon</a>


### PR DESCRIPTION
This PR fixes two small issues with the Mastodon share link:

1. Mastodon was not given a new line unlike all the other share links, so it was showing up right next to Tumblr.
2. The code that generated query params seems to have been copied from Tumblr or Facebook and it does not fill in the textbox correctly. Fix this so the prefilled "Toot" matches what Twitter share would post.

