### PR TITLE
API Rejects Pass With Colon: split only sitename from rest of pass to allow colon in pass

### DIFF
--- a/app/api.rb
+++ b/app/api.rb
@@ -200,7 +200,7 @@ def init_api_credentials
       api_key = bearer_match.captures.first
       api_error_invalid_auth if api_key.nil? || api_key.empty?
     else
-      user, pass = Base64.decode64(auth.match(/Basic (.+)/)[1]).split(':')
+      user, pass = Base64.decode64(auth.match(/Basic (.+)/)[1]).split(':', 2)
     end
   rescue
     api_error_invalid_auth


### PR DESCRIPTION
Greetings,

I made a small revision that will allow colons in passwords of users using the API.
Previously, the API distinguished the site name from the password by splitting on colons globally, but my change makes it so the API makes this distinction on just the first colon.

If the user/pass combo is malformed (does not contain colon) then the behavior is the same as before this change.
A password containing no colons also yields the same behavior as before this change.

Let me know if I need to do anything else with this PR before you can merge :)

Thanks!