### PR TITLE
Update Vagrant to latest Ubuntu LTS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'ubuntu/bionic64'
+  config.vm.box = 'ubuntu/jammy64'
   config.vm.provision :shell, path: './vagrant/development.sh'
   config.vm.network :forwarded_port, guest: 9292, host: 9292
 


### PR DESCRIPTION
Was working trying to get a dev environment set up via the readme.

There are quite a few dependencies in the 18.04 LTS repos that are out of date and cause a bundle install to fail for whatever reason. I think the default version of bundler in 18.04 is still major version 1 for example. There was a myriad of issues basically.

Updating to 22.04 went a long way in making sure I can apt install the correct dependencies, such as Ruby 3 etc. This isn't a comprehensive fix to several issues I encountered while trying to get the dev environment working (why work on improving the dev environment with limited time on a free site?), but I think this is a low hanging fruit that would hopefully make it less painful for people. Although it was still a minor trial by fire for me and I'm a better developer for it :D