### PR TITLE
Improve responsiveness for mobile screens for sites with large site stats

### DIFF
--- a/sass/_project-sass/_project-Main.scss
+++ b/sass/_project-sass/_project-Main.scss
@@ -1127,6 +1127,25 @@ a.tag:hover {
     margin-left: 0;
   }
 }
+
+.interior .header-Outro .col.col-50.signup-Area.site-display-preview-wrapper {
+  @media (max-device-width:480px), screen and (max-width:800px) {
+    padding: 0 7%;
+  }
+}
+
+.interior .header-Outro .site-display-preview {
+  @media (max-device-width:480px), screen and (max-width:800px) {
+    margin: 0 auto 5px;
+  }
+}
+
+.interior .header-Outro .site-info-row {
+  @media (max-device-width:480px), screen and (max-width:800px) {
+    padding: 20px 0%;
+  }
+}
+
 .interior .header-Outro .stats {
   margin-bottom: 1.3em;
   float: left;
@@ -1134,15 +1153,29 @@ a.tag:hover {
   margin-top: 1.9em;
 
   @media (max-device-width:480px), screen and (max-width:800px) {
-    float: none;
-    width: 270px;
-    margin: 0.9em auto 5.5em auto;
     text-align: center;
+    margin-top: 0.5em;
+    display: flex;
+    justify-content: center;
   }
 }
+
 .interior .header-Outro .stats .tips {
   @media (max-device-width:480px), screen and (max-width:800px) {
     display: none;
+  }
+}
+
+.interior .header-Outro .stats .stat {
+  float: left;
+  text-align: center;
+  margin-right: 28px;
+  color: #84997E;
+
+  @media (max-device-width:480px), screen and (max-width:800px) {
+    margin: 0;
+    width: fit-content;
+    min-width: 90px;
   }
 }
 
@@ -1157,17 +1190,7 @@ a.tag:hover {
   clear: both;
   display: block;
 }
-.interior .header-Outro .stats .stat {
-  float: left;
-  text-align: center;
-  margin-right: 28px;
-  color: #84997E;
 
-  @media (max-device-width:480px), screen and (max-width:800px) {
-    margin: 0;
-    width: 90px;
-  }
-}
 .interior .header-Outro .stats .stat.tips {
   width: 60px;
 }

--- a/views/site.erb
+++ b/views/site.erb
@@ -8,9 +8,9 @@
       </div>
     </div>
   <% end %>
-  <div class="row content">
-    <div class="col col-50 signup-Area large">
-      <div class="signup-Form">
+  <div class="row content site-info-row">
+    <div class="col col-50 signup-Area site-display-preview-wrapper large">
+      <div class="signup-Form site-display-preview">
   	  <fieldset class="content">
         <a href="<%= site.uri %>" class="screenshot" style="background-image:url(<%= site.screenshot_url('index.html', '540x405') %>);"></a>
 	    </fieldset>


### PR DESCRIPTION
This change improves stat display counters for small screens.

I tested with some ridiculous values and compared between my revision and the live site. This was at a resolution of 375px wide. 1 billion views, 20,000 followers, 100,000 updates. First is live site, then my revision.
![current](https://github.com/neocities/neocities/assets/6772127/277b3a72-d838-4aff-af8c-567625c32f6a)
![mine](https://github.com/neocities/neocities/assets/6772127/747fde01-2d46-49b7-8ece-8c71a21d1136)

Not perfect, but there's no overlapping text. I tried to keep the single row thing and keep it faithful to the original design.

Here are some more realistic large numbers: 1 million views, no followers (😥) and 100,000 updates. First is live site, then my revision.
![current 1m](https://github.com/neocities/neocities/assets/6772127/f925a490-3072-44bc-a03b-6543e76a6328)
![mine 1m](https://github.com/neocities/neocities/assets/6772127/62305672-348c-4edf-9d0f-148db073785a)

Whether this change is merged will probably depend on the philosophy of the site. I think this is the first display: flex used across the entire codebase. So I'm not sure if the philosophy is to support old browsers as much as possible, or whether (I think this is the case) the site was made 10 years ago before flex was a thing.