### PR TITLE
Attempt to route 404.html without actually testing it

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -509,7 +509,7 @@ task :generate_sitemap => [:environment] do
   site_files = []
 
   sites.each do |site|
-    site.site_files_dataset.exclude(path: 'not_found.html').where(path: /\.html?$/).all.each do |site_file|
+    site.site_files_dataset.exclude(path: 'not_found.html').exclude(path: '404.html').where(path: /\.html?$/).all.each do |site_file|
 
       if site.file_uri(site_file.path) == site.uri+'/'
         priority = 0.5

--- a/views/templates/domain.erb
+++ b/views/templates/domain.erb
@@ -8,7 +8,7 @@ server {
   error_page 404 = @notfound;
 
   location @notfound {
-      try_files /not_found.html @notfound_root;
+      try_files /not_found.html /404.html @notfound_root;
   }
 
   location @notfound_root {


### PR DESCRIPTION
I'm shooting in the dark so maybe this is a bad pull request. I searched the codebase for `not_found.html` and had these results
![image](https://github.com/neocities/neocities/assets/6772127/3f80ff70-84fa-414e-a052-c679bb65e994)


Five files contain the string `not_found.html`. For the ones in the middle, the first one is an API test. The second one is an erb/html template of an example for listing files from the API. The third one is an erb/html template of an example for listing files from the API. So only the top and bottom files seem to be relevant.

Addressing the first one, chaining together excludes is written elsewhere in the codebase, so to generate the sitemap exclude `404.html` as well as `not_found.html`. 

For nginx routing, `try_files /not_found.html /404.html @notfound_root;` so try not_found.html, then try 404.html, both on the user site, then if that fails return a default neocities `not_found.html` for people who have deleted theirs.

I'm out of my depth here, I didn't test this on a local nginx server or anything, I don't really know what I'm doing. Maybe you have a good reason not route `404.html` pages from user sites too, I don't know. But, I guess just expressing interest for this as a feature if this isn't actually the solution. Hopefully it is? 😬