### PR TITLE
Remove an erroneous 'a' from supporter.erb

### DIFF
--- a/views/settings/account/supporter.erb
+++ b/views/settings/account/supporter.erb
@@ -11,7 +11,7 @@
   <p class="tiny">
     You currently have the <strong>Free Plan (<%= current_site.maximum_space.to_space_pretty %>)</strong>.<br>Want to get more space and help Neocities? Become a supporter!
   </p>
-  <a href="/supporter">Supporter Info</a>a
+  <a href="/supporter">Supporter Info</a>
   <% if parent_site.stripe_customer_id || parent_site.paypal_profile_id %>
     <br>
     <a href="/settings/invoices">Generated Invoices</a>


### PR DESCRIPTION
This removes a visual bug which can be seen directly on Neocities: https://neocities.org/settings#supporter