### PR TITLE
I made a fix to prevent large portrait images from overflowing on certain resolutions

### DIFF
--- a/sass/_project-sass/_project-Main.scss
+++ b/sass/_project-sass/_project-Main.scss
@@ -808,7 +808,7 @@
 .large-portrait {
   border: 10px solid white;
   @include box-shadow(1px 1px 2px 1px rgba(0, 0, 0, 0.15));
-  width: 322px;
+  width: 100%;
   height: 241px;
   background-size: cover;
   float: left;


### PR DESCRIPTION
Before:
<img width="895" alt="Screenshot 2024-02-21 at 11 07 45 PM" src="https://github.com/neocities/neocities/assets/79779618/4522f810-27f9-4008-b51c-95baa8ec1b3f">

After:
<img width="890" alt="Screenshot 2024-02-21 at 11 07 35 PM" src="https://github.com/neocities/neocities/assets/79779618/140c9fa9-f33d-4721-b190-7cd949dd2f54">
