### PR TITLE
I made the site tag text color darker so it passes most WCAG accessibility standards.

### DIFF
--- a/sass/_project-sass/_project-Main.scss
+++ b/sass/_project-sass/_project-Main.scss
@@ -853,7 +853,7 @@ a.tag, a.tag:visited {
   font-size: .7em;
   text-transform: uppercase;
   background: #FFFFCC;
-  color: #C1A009!important;
+  color: #897106!important;
   float: left;
   padding: 1px 5px;
   -moz-box-shadow: 1px 1px 1px 0px rgba(0,0,0,0.2);


### PR DESCRIPTION
The original text color didn't pass any of the WCAG tests:
<img width="870" alt="Screenshot 2024-03-14 at 7 43 10 PM" src="https://github.com/neocities/neocities/assets/79779618/b9fb7849-d555-412d-99f8-00564cd19506">
This means that users with low vision won't be able to read the text in the tags very easily.

Using the luminance slider, I darkened the text color until it passed nearly all of the WCAG tests and most importantly the WCAG AA Normal Text test. I didn't darken it too much since I wanted to maintain a balance between aesthetics and function. Below are the the results:
<img width="880" alt="Screenshot 2024-03-14 at 7 44 20 PM" src="https://github.com/neocities/neocities/assets/79779618/b37b3dfa-8b9e-4da3-84ab-869143368b9f">
<img width="241" alt="Screenshot 2024-03-14 at 7 52 08 PM" src="https://github.com/neocities/neocities/assets/79779618/8cc01261-6089-48d6-a229-055d1ee458c7">
