### PR TITLE
Fix follows' "see more" link

### DIFF
--- a/views/_follows.erb
+++ b/views/_follows.erb
@@ -10,7 +10,7 @@
       <% end %>
 
       <% if Site::MAX_DISPLAY_FOLLOWS < site_followings_count %>
-        <a href="/site/<%= site.username %>/followers"><strong>see more <i class="fa fa-arrow-right"></i></strong></a>
+        <a href="/site/<%= site.username %>/follows"><strong>see more <i class="fa fa-arrow-right"></i></strong></a>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
"see more" link on follows shows incorrect link (goes to followers instead of follows)
![image](https://github.com/neocities/neocities/assets/26517362/efbe38b8-577b-4b5d-a1df-92608c24a0ad)

This PR fixes this