### PR TITLE
Update _project-Main.scss

### DIFF
--- a/sass/_project-sass/_project-Main.scss
+++ b/sass/_project-sass/_project-Main.scss
@@ -482,10 +482,15 @@
 .overlay a {
   color: white;
   text-decoration: none;
-  font-size: 14px;
+  font-size: 12px;
   display: block;
   margin-left: 5px;
 }
+
+.overlay a:hover {
+  font-size: 14px;
+}
+
 .overlay .fa-trash, .modal .fa-trash {
   vertical-align: 1px;
 }


### PR DESCRIPTION
Ameliorating issue #439 

* font of links on the overlay are smaller and thus further from file-open link  - you are less likely to click it by accident
* overlay font enlarges on hover so users can see clearly which they are about to click

Ideally, I would like to see an interaction when I hover over the file name, but that would require rethinking how the overlay is done.

It's not exactly what people reporting the issue asked for, but it does quickly improve the problem without redesigning the UI 

