### PR TITLE
feature: use current_site.commenting_allowed? on Likes

### DIFF
--- a/views/_news.erb
+++ b/views/_news.erb
@@ -143,7 +143,9 @@
           <div class="actions">
             <% comment_likes_count = comment.comment_likes_dataset.count %>
             <% if current_site %>
-              <a href="#" class="comment_like" id="comment_<%= comment.id %>_like" data-placement="bottom" data-toggle="tooltip" data-original-title="<%= comment.liking_site_usernames.join('<br>') %>" onclick="Comment.toggleLike(<%= comment.id %>, '<%= csrf_token %>'); return false"><%= comment.site_likes?(current_site) ? 'Unlike' : 'Like' %><%= comment_likes_count > 0 ? " (#{comment_likes_count})" : '' %></a>
+              <% if current_site.commenting_allowed? %>
+                <a href="#" class="comment_like" id="comment_<%= comment.id %>_like" data-placement="bottom" data-toggle="tooltip" data-original-title="<%= comment.liking_site_usernames.join('<br>') %>" onclick="Comment.toggleLike(<%= comment.id %>, '<%= csrf_token %>'); return false"><%= comment.site_likes?(current_site) ? 'Unlike' : 'Like' %><%= comment_likes_count > 0 ? " (#{comment_likes_count})" : '' %></a>
+              <% end %>
             <% else %>
               <% if comment_likes_count > 0 %>
                 <%= comment_likes_count %>&nbsp;<%= comment_likes_count == 1 ? 'like' : 'likes' %>

--- a/views/_news_actions.erb
+++ b/views/_news_actions.erb
@@ -1,7 +1,9 @@
 <div id="event_<%= event.id %>_actions" class="actions">
   <% event_likes_count = event.likes_dataset.count %>
   <% if current_site %>
-    <a href="#" id="like" data-placement="bottom" data-toggle="tooltip" data-original-title="<%= event.liking_site_usernames.join('<br>') %>" onclick="new Like(<%= event.id %>, '<%= csrf_token %>').toggleLike(); return false"><%= event.site_likes?(current_site) ? 'Unlike' : 'Like' %><%= event_likes_count > 0 ? " (#{event_likes_count})" : '' %></a>
+    <% if current_site.commenting_allowed? %>
+      <a href="#" class="comment_like" id="comment_<%= comment.id %>_like" data-placement="bottom" data-toggle="tooltip" data-original-title="<%= comment.liking_site_usernames.join('<br>') %>" onclick="Comment.toggleLike(<%= comment.id %>, '<%= csrf_token %>'); return false"><%= comment.site_likes?(current_site) ? 'Unlike' : 'Like' %><%= comment_likes_count > 0 ? " (#{comment_likes_count})" : '' %></a>
+    <% end %>
   <% else %>
     <% if event_likes_count > 0 %>
       <%= event_likes_count %>&nbsp;<%= event_likes_count == 1 ? 'like' : 'likes' %>


### PR DESCRIPTION
I'm not sure if you want to solve this this way. If you don't, I don't entirely blame you as it is using the functionality intended to determine if comments should be allowed on likes. But it seems like if comments aren't allowed, why should likes be?

Of course this is only removing the option from the template. It doesn't stop someone from creating the like with a post request. But maybe this is enough. Its your call. Maybe its a starting point to think about the problem at least.