### PR TITLE
Smoother responsive site stats page

### DIFF
--- a/sass/_project-sass/_project-Main.scss
+++ b/sass/_project-sass/_project-Main.scss
@@ -1118,10 +1118,26 @@ a.tag:hover {
   color: #999;
 }
 .interior .header-Outro .profile-info {
+  padding-left: 35px;
+  
+  h2 {
+    padding-right: 10px;
+  }
+  
+  .actions {
+    padding-bottom: 10px;
+  }
+
   @media (max-device-width:480px), screen and (max-width:800px) {
-    margin-top: 70px;
     text-align: center;
     padding: 10px 0 15px 0;
+
+    h2 {
+      margin-top: 0;
+    }
+    .actions {
+      padding-bottom: 0;
+    }
   }
 }
 .interior .header-Outro .actions {
@@ -1134,10 +1150,20 @@ a.tag:hover {
   }
 }
 
-.interior .header-Outro .col.col-50.signup-Area.site-display-preview-wrapper {
+.interior .header-Outro  {
   @media (max-device-width:480px), screen and (max-width:800px) {
     padding: 0 7%;
   }
+}
+
+.signup-Area.site-display-preview-wrapper {
+  @media (max-device-width:480px), screen and (max-width:800px) {
+    padding: 0 5%;
+  }
+}
+
+.website-thumbnail-wrapper {
+  padding: 20px;
 }
 
 .interior .header-Outro .site-display-preview {
@@ -1146,9 +1172,32 @@ a.tag:hover {
   }
 }
 
-.interior .header-Outro .site-info-row {
+.interior .header-Outro {
   @media (max-device-width:480px), screen and (max-width:800px) {
     padding: 20px 0%;
+  }
+}
+
+.site-profile-big-container {
+  padding-bottom: 0 !important;
+}
+
+.site-info-row {
+  display: flex;
+  padding: 20px 3% 20px 0;
+  padding-bottom: 0;
+
+  fieldset{
+    padding: 20px;
+    background: linear-gradient(to top, #394650 0%, 60%, hsl(206, 32%, 30%) 100%);
+    border-radius: 4px 4px 0 0;
+    box-shadow: 1px 2px 12px 2px rgba(0, 0, 0, 0.15);
+    -webkit-box-shadow: 1px 2px 12px 2px rgba(0, 0, 0, 0.15);
+  }
+
+  @media (max-device-width:480px), screen and (max-width:800px) {
+    padding: 20px 3% 0 3%;
+    display: block;
   }
 }
 
@@ -1157,11 +1206,11 @@ a.tag:hover {
   float: left;
   width: 100%;
   margin-top: 1.9em;
+  display: flex;
 
   @media (max-device-width:480px), screen and (max-width:800px) {
     text-align: center;
     margin-top: 0.5em;
-    display: flex;
     justify-content: center;
   }
 }

--- a/views/site.erb
+++ b/views/site.erb
@@ -1,4 +1,4 @@
-<div class="header-Outro with-site-image">
+<div class="header-Outro with-site-image site-profile-big-container">
   <% if flash.keys.length > 0 %>
     <div class="row content">
       <div class="alert txt-Center">
@@ -9,14 +9,14 @@
     </div>
   <% end %>
   <div class="row content site-info-row">
-    <div class="col col-50 signup-Area site-display-preview-wrapper large">
-      <div class="signup-Form site-display-preview">
-  	  <fieldset class="content">
+    <div class="signup-Area site-display-preview-wrapper">
+      <div class="site-display-preview">
+  	  <fieldset class="website-thumbnail-wrapper">
         <a href="<%= site.uri %>" class="screenshot" style="background-image:url(<%= site.screenshot_url('index.html', '540x405') %>);"></a>
 	    </fieldset>
       </div>
     </div>
-    <div class="col col-50 profile-info">
+    <div class="profile-info">
       <h2 class="eps title-with-badge"><span><%= site.title %></span> <% if site.supporter? %><a href="/supporter" class="supporter-badge" title="Neocities Supporter"></a> <% end %></h2>
       <p class="site-url"><a href="<%= site.uri %>"><%= site.host %></a></p>
       <% follow_count = site.follows_dataset.count %>


### PR DESCRIPTION
When resizing the width of a website's stats page, this happens where stats get crumpled to one side e.g.:

![image](https://github.com/user-attachments/assets/3609756f-2f8f-43ba-8f02-fcc0d2a8f379)

As well as some other non-smooth breakpoints here and there causing stuff to jump around.

In a nutshell this PR should make the experience of resizing the window on the stats screen buttery smooth.

Before:
![image](https://github.com/user-attachments/assets/26f0fee7-5588-49f2-ad84-d12c322a5280)

After:
![image](https://github.com/user-attachments/assets/091a1a18-57bc-4e90-99cc-0043227f96a7)

With the same window width. The Send a Tip button is visible as expected at all widths, I just added it in at the last moment to check that was good too.