### PR TITLE
Responsive feed image

### DIFF
--- a/sass/_project-sass/_project-Main.scss
+++ b/sass/_project-sass/_project-Main.scss
@@ -1002,7 +1002,6 @@ a.tag:hover {
   }
   &:first-child .html-thumbnail.html {
     width: 540px;
-    height: 405px;
     @media (max-device-width:480px), screen and (max-width:800px) {
       width: 270px;
       height: 202px;

--- a/sass/_project-sass/_project-Main.scss
+++ b/sass/_project-sass/_project-Main.scss
@@ -1002,14 +1002,18 @@ a.tag:hover {
   }
   &:first-child .html-thumbnail.html {
     width: 540px;
+    height: 405px;
     @media (max-device-width:480px), screen and (max-width:800px) {
       width: 270px;
       height: 202px;
     }
   }
   &:first-child .html-thumbnail.html img {
-    width: 540px;
-    height: 405px;
+    aspect-ratio: 540 / 405;
+    height: auto;
+    max-width: 540px;
+    width: 52vw;
+    float: left;
     @media (max-device-width:480px), screen and (max-width:800px) {
       width: 270px;
       height: 202px;


### PR DESCRIPTION
On user's feeds, site thumbnails overflow the feed list area on resolutions in between desktop and mobile. I fixed this by updating some SCSS. 

**Before:**
<img width="605" alt="Screenshot 2024-08-15 at 7 17 25 PM" src="https://github.com/user-attachments/assets/9c3a3bb1-de64-49d4-856d-70db0d63aa3a" >

**After:**
<img width="607" alt="Screenshot 2024-08-15 at 7 17 38 PM" src="https://github.com/user-attachments/assets/cf657cd5-a663-4385-b03e-c56d188e7d38" >
