### PR TITLE
Accessibility Improvements on Neocitie's Index Page

### DIFF
--- a/sass/_project-sass/_project-Footer.scss
+++ b/sass/_project-sass/_project-Footer.scss
@@ -9,7 +9,7 @@
   width: 100%;
 
 	h1, h2, h3, h4{
-  	color:#8b9a7a;
+  	color:#5b694f;
 	}
 }
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -263,10 +263,10 @@
 
   <div class="col col-100">
     <div class="row press">
-      <a href="http://www.wired.com/2013/07/neocities/" class="logo wired"></a>
-      <a href="http://www.fastcodesign.com/3037028/why-the-internet-is-time-traveling-back-to-1994" class="logo fastco"></a>
-      <a href="http://motherboard.vice.com/blog/neocities-is-recreating-the-garish-web-10-creativity-of-geocities" class="logo vice"></a>
-      <a href="http://arstechnica.com/tech-policy/2014/05/web-host-gives-fcc-a-28-8kbps-slow-lane-in-net-neutrality-protest/" class="logo ars"></a>
+      <a href="http://www.wired.com/2013/07/neocities/" class="logo wired" aria-label="Article on Wired about Neocities"></a>
+      <a href="http://www.fastcodesign.com/3037028/why-the-internet-is-time-traveling-back-to-1994" class="logo fastco" aria-label="Article on Fast Company about Neocities"></a>
+      <a href="http://motherboard.vice.com/blog/neocities-is-recreating-the-garish-web-10-creativity-of-geocities" class="logo vice" aria-label="Article on Vice about Neocities"></a>
+      <a href="http://arstechnica.com/tech-policy/2014/05/web-host-gives-fcc-a-28-8kbps-slow-lane-in-net-neutrality-protest/" class="logo ars" aria-label="Article on Ars Technica about Neocities"></a>
       <!--<a href="/press" class="more">See all press »</a>-->
     </div>
     <div class="row quote">

--- a/views/index.erb
+++ b/views/index.erb
@@ -265,7 +265,7 @@
     <div class="row press">
       <a href="http://www.wired.com/2013/07/neocities/" class="logo wired" aria-label="Article on Wired about Neocities"></a>
       <a href="http://www.fastcodesign.com/3037028/why-the-internet-is-time-traveling-back-to-1994" class="logo fastco" aria-label="Article on Fast Company about Neocities"></a>
-      <a href="http://motherboard.vice.com/blog/neocities-is-recreating-the-garish-web-10-creativity-of-geocities" class="logo vice" aria-label="Article on Vice about Neocities"></a>
+      <a href="https://www.vice.com/en/article/neocities-is-recreating-the-garish-web-10-creativity-of-geocities/" class="logo vice" aria-label="Article on Vice about Neocities"></a>
       <a href="http://arstechnica.com/tech-policy/2014/05/web-host-gives-fcc-a-28-8kbps-slow-lane-in-net-neutrality-protest/" class="logo ars" aria-label="Article on Ars Technica about Neocities"></a>
       <!--<a href="/press" class="more">See all press »</a>-->
     </div>


### PR DESCRIPTION
The footer headers did not have a WCAG compliant contrast ratio:
<img width="400" alt="Screenshot 2024-08-15 at 8 58 23 PM" src="https://github.com/user-attachments/assets/0eb59d1f-ea58-44cf-bade-77f406be21a6">

I darkened the text color to improve WCAG complaince:
<img width="400" alt="Screenshot 2024-08-15 at 8 52 12 PM" src="https://github.com/user-attachments/assets/42858f59-5127-472d-be16-21eb74132d74">

The press links for Wired, Ars Technica, etc, didn't have discernible names for screen readers so I added Aria labels for them.

These edits should improve the index page's Google Lighthouse score in the accessibility category.