### PR TITLE
Code Editor Settings for Monaco

### DIFF
--- a/app/settings.rb
+++ b/app/settings.rb
@@ -307,6 +307,18 @@ post '/settings/change_email_notification' do
   redirect '/settings#email'
 end
 
+post '/settings/change_editor_settings' do
+  require_login
+
+  owner = current_site.owner
+
+  owner.autocomplete_enabled = params[:autocomplete_enabled]
+  owner.vimmode_enabled = params[:vimmode_enabled]
+  owner.save_changes validate: false
+  flash[:success] = 'Code editor settings have been updated.'
+  redirect '/settings#editor'
+end
+
 post '/settings/create_child' do
   require_login
 

--- a/migrations/128_add_sites_editor_settings.rb
+++ b/migrations/128_add_sites_editor_settings.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  up {
+    DB.add_column :sites, :autocomplete_enabled, :boolean, default: false
+    DB.add_column :sites, :vimmode_enabled, :boolean, default: false
+  }
+
+  down {
+    DB.add_column :sites, :autocomplete_enabled
+    DB.add_column :sites, :vimmode_enabled
+  }
+end
+

--- a/migrations/129_add_vimmode_setting.rb
+++ b/migrations/129_add_vimmode_setting.rb
@@ -1,0 +1,10 @@
+Sequel.migration do
+  up {
+    DB.add_column :sites, :vimmode_enabled, :boolean, default: false
+  }
+
+  down {
+    DB.add_column :sites, :vimmode_enabled
+  }
+end
+

--- a/views/settings/account.erb
+++ b/views/settings/account.erb
@@ -25,6 +25,7 @@
         <ul class="nav nav-tabs">
 
           <li class="active"><a href="#sites" data-toggle="tab">Sites</a></li>
+          <li><a href="#editor" data-toggle="tab">Editor</a></li>
           <li><a href="#supporter" data-toggle="tab">Supporter</a></li>
           <li><a href="#password" data-toggle="tab">Password</a></li>
           <li><a href="#email" data-toggle="tab">Email</a></li>
@@ -38,6 +39,9 @@
         <div class="tab-content">
           <div class="tab-pane active" id="sites">
             <%== erb :'settings/account/sites' %>
+          </div>
+          <div class="tab-pane" id="editor">
+            <%== erb :'settings/account/editor' %>
           </div>
           <div class="tab-pane" id="supporter">
             <%== erb :'settings/account/supporter' %>

--- a/views/settings/account/editor.erb
+++ b/views/settings/account/editor.erb
@@ -1,0 +1,28 @@
+<h2>Code Editor Settings</h2>
+<form method="POST" action="/settings/change_editor_settings">
+  <%== csrf_token_input_html %>
+
+  <p>
+    Enable Autocomplete:
+    <input name="autocomplete_enabled" type="hidden" value="false">
+    <input name="autocomplete_enabled" type="checkbox" value="true"
+      <% if current_site.owner.autocomplete_enabled %>
+        checked
+      <% end %>
+    >
+  </p>
+  <p>
+    Enable Vim Mode:
+    <input name="vimmode_enabled" type="hidden" value="false">
+    <input name="vimmode_enabled" type="checkbox" value="true"
+      <% if current_site.owner.vimmode_enabled %>
+        checked
+      <% end %>
+    >
+  </p>
+
+  <div>
+    <input class="btn-Action" type="submit" value="Update Notification Settings">
+  </div>
+</form>
+

--- a/views/settings/account/editor.erb
+++ b/views/settings/account/editor.erb
@@ -3,7 +3,7 @@
   <%== csrf_token_input_html %>
 
   <p>
-    Enable Autocomplete:
+    Enable Code Suggestions:
     <input name="autocomplete_enabled" type="hidden" value="false">
     <input name="autocomplete_enabled" type="checkbox" value="true"
       <% if current_site.owner.autocomplete_enabled %>

--- a/views/site_files/text_editor.erb
+++ b/views/site_files/text_editor.erb
@@ -292,14 +292,21 @@
               bottom: 25
             },
             fixedOverflowWidgets: true,
-            suggestOnTriggerCharacters: false,
+            // idk if this is the best syntax but it works
+            <% if current_site.autocomplete_enabled %>
+              suggestOnTriggerCharacters: true,
+            <% else %>
+              suggestOnTriggerCharacters: false,
+            <% end %>
             quickSuggestions: false,
             parameterHints: {
               enabled: false
             }
           });
+          <% if current_site.vimmode_enabled %>
           var statusNode = document.getElementById('status');
           var vimMode = MonacoVim.initVimMode(editor, statusNode);
+          <% end %>
           setTheme();
 
 

--- a/views/site_files/text_editor.erb
+++ b/views/site_files/text_editor.erb
@@ -101,6 +101,8 @@
       <span class="hide-on-mobile">
         <a class="btn-Action" href="<%= current_site.uri @filename %>" target="_blank"><i class="fa fa-globe"></i> View</a>
         <a href="#" id="shareButton" class="btn-Action" data-container="body" data-toggle="popover" data-placement="bottom" data-content='<%== erb :'_share', layout: false, locals: {site: current_site, page_uri: "#{current_site.uri}/#{@filename}"} %>'><i class="fa fa-share-alt chat-button"></i> Share</a><!-- <% if current_site.supporter? %><a class="btn-Action" id="chatButton"><i class="fa fa-comments"></i> Penelope <span style="font-size: 8pt">(beta)</span></a><% end %> -->
+        <a id="settingsButton" class="btn-Action" href="/settings#editor"><i class="fa fa-gear"></i> Settings</a>
+
       </span>
     <!-- <a id="saveAndExitButton" class="btn-Action" href="#" onclick="saveTextFile(true); return false" style="opacity: 0.5"><i class="fa fa-save"></i>&nbsp;&nbsp;Save and Exit</a> -->
       <div id="editorUpdates" class="tooltip fade bottom in hidden" style="top: 90px;right: 12.5em;">
@@ -156,7 +158,10 @@
       return `/monaco/min/vs/base/worker/workerMain.js`;
     }
   };
-  require.config({ paths: { 'vs': '/monaco/min/vs' } });
+  require.config({ paths: { 
+    'vs': '/monaco/min/vs', 
+    'monaco-vim': 'https://unpkg.com/monaco-vim/dist/monaco-vim', 
+  } });
 
   var unsavedChanges = false
 
@@ -251,7 +256,7 @@
 
   var editor = {}
 
-  require(['vs/editor/editor.main'], function() {
+  require(['vs/editor/editor.main', 'monaco-vim'], function(a, MonacoVim) {
     $(document).ready(function() {
       $.ajax({
         url: "/site_files/download/<%= Site.escape_path(@filename) %>",
@@ -293,6 +298,8 @@
               enabled: false
             }
           });
+          var statusNode = document.getElementById('status');
+          var vimMode = MonacoVim.initVimMode(editor, statusNode);
           setTheme();
 
 


### PR DESCRIPTION
@kyledrake I went ahead and added settings for the code editor for users to enable/disable code completion suggestions as well as a vim input mode. (I'm not sure how many people are vim users but I personally wanted this one so I threw it in)

I think this could also be expanded on in the future to allow people to change stuff like the font size of the editor, upload their own themes, etc.

My only part of this PR I'm not 100% happy with is that I could not find a way to get the vim motions package to work when serving locally I had to use a CDN. I'm sure this can be figured out but for the sake of my time I'm just sending this as is. Here's the link to the repo for the plugin tho. [monaco-vim](https://github.com/brijeshb42/monaco-vim)