### PR TITLE
Drag and Drop In File Explorer

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -38,7 +38,7 @@ function hideMovingProgress() {
   $('#movingOverlay').css('display', 'none');
 }
 
-function moveFileToFolder(event, folderName, dragBack) {
+function moveFileToFolder(event, folderName) {
   event.preventDefault();
   event.stopPropagation();
 

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -38,10 +38,17 @@ function hideMovingProgress() {
   $('#movingOverlay').css('display', 'none');
 }
 
-function moveFile(fileName, folderName, dragBack) {
+function moveFileToFolder(event, folderName, dragBack) {
+  event.preventDefault();
+  event.stopPropagation();
+
+  const fullUrl = event.dataTransfer.getData('text/uri-list');
+  const url = new URL(fullUrl);
+  let fileName = url.pathname;
+
   $('#moveCurrentPath').val(fileName.slice(1));
   fileName = fileName.split('/').pop(); 
-  $('#moveNewPath').val(folderName + '/' +fileName);
+  $('#moveNewPath').val(folderName + '/' + fileName);
   $('#moveFileForm').submit();
 }
 

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -30,6 +30,22 @@ function hideUploadProgress() {
   $('#uploadingOverlay').css('display', 'none')
 }
 
+function showMovingProgress() {
+  $('#movingOverlay').css('display', 'block');
+}
+
+function hideMovingProgress() {
+  $('#movingOverlay').css('display', 'none');
+}
+
+function moveFile(fileName, folderName) {
+  console.log(fileName);
+  console.log(folderName);
+  $('#moveCurrentPath').val(fileName.slice(1));
+  $('#moveNewPath').val(folderName + fileName);
+  $('#moveFileForm').submit();
+}
+
 $('#createDir').on('shown', function () {
   $('#newDirInput').focus();
 })

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -38,11 +38,10 @@ function hideMovingProgress() {
   $('#movingOverlay').css('display', 'none');
 }
 
-function moveFile(fileName, folderName) {
-  console.log(fileName);
-  console.log(folderName);
+function moveFile(fileName, folderName, dragBack) {
   $('#moveCurrentPath').val(fileName.slice(1));
-  $('#moveNewPath').val(folderName + fileName);
+  fileName = fileName.split('/').pop(); 
+  $('#moveNewPath').val(folderName + '/' +fileName);
   $('#moveFileForm').submit();
 }
 

--- a/views/dashboard/files.erb
+++ b/views/dashboard/files.erb
@@ -19,7 +19,7 @@
     <% if params[:dir].nil? || params[:dir].empty? || params[:dir] == '/' %>
       Home
     <% else %>
-      <a href="/dashboard" ondrop="moveFileToFolder(event, '', true)" ondragover="event.preventDefault()">Home</a>
+      <a href="/dashboard" ondrop="moveFileToFolder(event, '')" ondragover="event.preventDefault()">Home</a>
     <% end %>
 
     <% if @dir %>
@@ -27,7 +27,7 @@
       <% dir_array.each_with_index do |dir,i| %>
         <% if i+1 < dir_array.length %>
           <a href="/dashboard?dir=<%= Rack::Utils.escape dir_array[1..i].join('/') %>" 
-           ondrop="moveFileToFolder(event, '<%= dir_array[1..i].join('/') %>', true)" 
+           ondrop="moveFileToFolder(event, '<%= dir_array[1..i].join('/') %>')" 
            ondragover="event.preventDefault()"><%= dir %></a> <i class="fa fa-angle-right"></i>
         <% else %>
           <%= dir %>
@@ -60,7 +60,7 @@
               <div class="overlay"></div>
             </div>
           <% elsif file[:is_directory] %>
-            <div class="html-thumbnail folder fileimagehover" ondrop="moveFileToFolder(event, '<%= file[:path] %>', false)" ondragover="event.preventDefault()">
+            <div class="html-thumbnail folder fileimagehover" ondrop="moveFileToFolder(event, '<%= file[:path] %>')" ondragover="event.preventDefault()">
               <div class="folder-icon"></div>
               <div class="overlay"></div>
             </div>

--- a/views/dashboard/files.erb
+++ b/views/dashboard/files.erb
@@ -1,16 +1,3 @@
-<script>
-function moveFileToFolder(event, folderName, dragBack) {
-  event.preventDefault();
-  event.stopPropagation();
-
-  const fullUrl = event.dataTransfer.getData('text/uri-list');
-  const url = new URL(fullUrl);
-  let relativeUrl = url.pathname;
-
-  moveFile(relativeUrl, folderName, dragBack);
-}
-</script>
-
 <div id="uploadingOverlay" class="uploading-overlay" style="display: none">
   <div class="uploading">
       <p>Uploading, please wait...</p>

--- a/views/dashboard/files.erb
+++ b/views/dashboard/files.erb
@@ -1,3 +1,16 @@
+<script>
+function moveFileToFolder(event, folderName) {
+  event.preventDefault();
+  event.stopPropagation();
+
+  const fullUrl = event.dataTransfer.getData('text/uri-list');
+  const url = new URL(fullUrl);
+  const relativeUrl = url.pathname;
+
+  moveFile(relativeUrl, folderName);
+}
+</script>
+
 <div id="uploadingOverlay" class="uploading-overlay" style="display: none">
   <div class="uploading">
       <p>Uploading, please wait...</p>
@@ -58,7 +71,7 @@
               <div class="overlay"></div>
             </div>
           <% elsif file[:is_directory] %>
-            <div class="html-thumbnail folder fileimagehover" ondrop="moveFileToFolder(event)">
+            <div class="html-thumbnail folder fileimagehover" ondrop="moveFileToFolder(event, '<%= file[:path] %>')" ondragover="event.preventDefault()">
               <div class="folder-icon"></div>
               <div class="overlay"></div>
             </div>

--- a/views/dashboard/files.erb
+++ b/views/dashboard/files.erb
@@ -1,13 +1,13 @@
 <script>
-function moveFileToFolder(event, folderName) {
+function moveFileToFolder(event, folderName, dragBack) {
   event.preventDefault();
   event.stopPropagation();
 
   const fullUrl = event.dataTransfer.getData('text/uri-list');
   const url = new URL(fullUrl);
-  const relativeUrl = url.pathname;
+  let relativeUrl = url.pathname;
 
-  moveFile(relativeUrl, folderName);
+  moveFile(relativeUrl, folderName, dragBack);
 }
 </script>
 
@@ -32,14 +32,16 @@ function moveFileToFolder(event, folderName) {
     <% if params[:dir].nil? || params[:dir].empty? || params[:dir] == '/' %>
       Home
     <% else %>
-      <a href="/dashboard">Home</a>
+      <a href="/dashboard" ondrop="moveFileToFolder(event, '', true)" ondragover="event.preventDefault()">Home</a>
     <% end %>
 
     <% if @dir %>
       <% dir_array = @dir.split '/' %>
       <% dir_array.each_with_index do |dir,i| %>
         <% if i+1 < dir_array.length %>
-          <a href="/dashboard?dir=<%= Rack::Utils.escape dir_array[1..i].join('/') %>"><%= dir %></a> <i class="fa fa-angle-right"></i>
+          <a href="/dashboard?dir=<%= Rack::Utils.escape dir_array[1..i].join('/') %>" 
+           ondrop="moveFileToFolder(event, '<%= dir_array[1..i].join('/') %>', true)" 
+           ondragover="event.preventDefault()"><%= dir %></a> <i class="fa fa-angle-right"></i>
         <% else %>
           <%= dir %>
         <% end %>
@@ -71,7 +73,7 @@ function moveFileToFolder(event, folderName) {
               <div class="overlay"></div>
             </div>
           <% elsif file[:is_directory] %>
-            <div class="html-thumbnail folder fileimagehover" ondrop="moveFileToFolder(event, '<%= file[:path] %>')" ondragover="event.preventDefault()">
+            <div class="html-thumbnail folder fileimagehover" ondrop="moveFileToFolder(event, '<%= file[:path] %>', false)" ondragover="event.preventDefault()">
               <div class="folder-icon"></div>
               <div class="overlay"></div>
             </div>

--- a/views/dashboard/index.erb
+++ b/views/dashboard/index.erb
@@ -112,6 +112,13 @@
         </form>
       </div>
 
+      <form id="moveFileForm" method="post" action="/site_files/rename">
+          <input type="hidden" value="<%= csrf_token %>" name="csrf_token">
+          <input type="hidden" value="<%= @dir %>" name="dir">
+          <input type="hidden" id="moveCurrentPath" name="path">
+          <input type="hidden" id="moveNewPath" name="new_path">
+      </form>
+
 
 <div class="site-actions" style="margin-bottom:25px">
   <% if !current_site.plan_feature(:no_file_restrictions) %>


### PR DESCRIPTION
Added the ability to drag and drop files into folders and the ability to drag a file to a destination on the breadcrumb trail at the top to move the file backwards up the path.

A much needed feature to polish out the file explorer, no new api functionality was needed, this simply wraps the rename feature with some javascript event handling.