### PR TITLE
Make ACME challenge cleanup more specific

### DIFF
--- a/workers/lets_encrypt_worker.rb
+++ b/workers/lets_encrypt_worker.rb
@@ -187,7 +187,7 @@ class LetsEncryptWorker
   end
 
   def clean_wellknown_turds(site)
-    wellknown_path = File.join(site.base_files_path, '.well-known')
+    wellknown_path = File.join(site.base_files_path, '.well-known', 'acme-challenge')
 
     if File.exist?(wellknown_path)
       FileUtils.rm_rf wellknown_path


### PR DESCRIPTION
The .well-known directory has uses other than ACME challenge response, so deleting the whole thing as cleanup is incorrect.

I ran into an issue where files I uploaded inside that directory (which worked initially) disappeared after a while, I assume around the time neocities renewed the certs for my custom domain and this cleanup code ran. The file (and the .well-known dir) still appeared in GETs on the /api/list endpoint, but requests for them on my site returned 404. I tried to re-upload the original to the same path but it appears since it had the same content some optimization was preventing it from restoring the deleted file, because it continued to 404.

Uploading the same file to a different path inside .well-known worked, and then uploading a file with different content to the original path worked.

This commit changes the ACME cleanup code to only remove the .well-known/acme-challenge directory that it uses, and leaves any other files alone.

I'm not sure how to test this (lmk if I can help with that) or really how to even test my theory on why the files disappeared. This appears to be the only file in the repo that refers to `.well-known`, and IMO it provides a plausible explanation for my problem, but i'd be interested in other takes.