### PR TITLE
Support more than 6 thumbnails in news events

### DIFF
--- a/models/site_change.rb
+++ b/models/site_change.rb
@@ -6,7 +6,7 @@ class SiteChange < Sequel::Model
   one_to_one  :site_change
   one_to_many :site_change_files
 
-  def site_change_filenames(limit=6)
+  def site_change_filenames(limit=30)
     site_change_files_dataset.select(:filename).limit(limit).order(:created_at.desc).all.collect {|f| f.filename}.sort_by {|f| f.match('html') ? 0 : 1}
   end
 

--- a/sass/_project-sass/_project-Main.scss
+++ b/sass/_project-sass/_project-Main.scss
@@ -1007,6 +1007,14 @@ a.tag:hover {
       height: 202px;
     }
   }
+  &.big-file .html-thumbnail.html img {
+    width: 540px;
+    height: 405px;
+    @media (max-device-width:480px), screen and (max-width:800px) {
+      width: 270px;
+      height: 202px;
+    }
+  }
 }
 .news-item .file .image-container {
   float: left;

--- a/sass/_project-sass/_project-Main.scss
+++ b/sass/_project-sass/_project-Main.scss
@@ -999,15 +999,7 @@ a.tag:hover {
   .html-thumbnail {
     width: 102px;
   }
-  &:first-child .html-thumbnail.html {
-    width: 540px;
-    height: 405px;
-    @media (max-device-width:480px), screen and (max-width:800px) {
-      width: 270px;
-      height: 202px;
-    }
-  }
-  &:first-child .html-thumbnail.html img {
+  &.big-file .html-thumbnail.html {
     width: 540px;
     height: 405px;
     @media (max-device-width:480px), screen and (max-width:800px) {

--- a/views/_news.erb
+++ b/views/_news.erb
@@ -92,8 +92,8 @@
       <% unless site_change_filenames.empty? %>
         <div class="content">
           <div class="files">
-            <% site_change_filenames.each do |f| %>
-              <div class="file">
+            <% site_change_filenames.each.with_index do |f, i| %>
+              <div class="file <%= i == 0 && site_change_filenames.length <= 6 ? 'big-file' : '' %>">
                 <div class="html-thumbnail <%= site_change_file_display_class f %>">
                   <a href="https://<%= event_site.host %><%= f == 'index.html' ? '' : "/#{f}" %>">
                     <% if site_change_file_display_class(f) == 'html' %>


### PR DESCRIPTION
Following up on this comment https://github.com/neocities/neocities-ruby/pull/51#issuecomment-2243929262

Changes:
- Increase maximum thumbnail count (30 is somewhat arbitrary, it seemed to fit nicely).
- <strike>Remove redundant CSS for the thumbnail list (same styles applied to both the img and its parent, only relevant if the screenshot is smaller than the parent which as far as I can tell should never be the case. Initially was added in 876a701be196185773b8e18df2866f43e93905e8)</strike>
- Switch from using a CSS selector to using a HTML class for denoting the larger preview image. This isn't ideal, but CSS doesn't have a way that I'm aware of to count children.

<strike>Testing was a little tough, did my best to get the screenshot worker running but it seems like there's a screenshot service which doesn't live in this repo and doesn't seem to live in the neocities GH org at all (specified in [`config['screenshot_urls']`](https://github.com/neocities/neocities/blob/db3597121700b0189594c3fbd8d47aa8203e61ae/workers/screenshot_worker.rb#L38))?</strike> Got a screenshot test using my branch here: https://github.com/wayword-dev/neocities/tree/wayword/dockerize