### PR TITLE
Add .feedignore support to filter site change files + template during site creation

### DIFF
--- a/models/site.rb
+++ b/models/site.rb
@@ -499,6 +499,14 @@ class Site < Sequel::Model
     FileUtils.cp template_file_path('robots.txt'), tmpfile.path
     files << {filename: 'robots.txt', tempfile: tmpfile}
 
+    tmpfile = Tempfile.new '.feedignore'
+    tmpfile.write "# Use .feedignore to prevent certain files from showing up in the update feed.\n"
+    tmpfile.write "# You can name specific files, or use the * wildcard.\n\n# Ignore this file\n.feedignore\n\n"
+    tmpfile.write "# Ignore all files in the test/ directory\ntest/*"
+    tmpfile.write "\n\n"
+    tmpfile.close
+    files << {filename: '.feedignore', tempfile: tmpfile}
+
     store_files files, new_install: true
   end
 

--- a/models/site_change.rb
+++ b/models/site_change.rb
@@ -7,10 +7,14 @@ class SiteChange < Sequel::Model
   one_to_many :site_change_files
 
   def site_change_filenames(limit=6)
-    site_change_files_dataset.select(:filename).limit(limit).order(:created_at.desc).all.collect {|f| f.filename}.sort_by {|f| f.match('html') ? 0 : 1}
+    filenames = site_change_files_dataset.select(:filename).limit(limit).order(:created_at.desc).all.collect {|f| f.filename}
+    filenames = filenames.reject { |f| site.should_ignore_from_feed?(f) }
+    filenames.sort_by {|f| f.match('html') ? 0 : 1}
   end
 
   def self.record(site, filename)
+    return if site.should_ignore_from_feed?(filename)
+
     site_change = filter(site_id: site.id).order(:created_at.desc).first
 
     if site_change.nil? || site_change.created_at+NEW_CHANGE_TIMEOUT < Time.now


### PR DESCRIPTION
# Add .feedignore support for site updates feed

Adds the ability for users to control which files appear in their site's update feed
by adding a .feedignore file to their site's root directory. Similar to .gitignore,
this feature allows users to specify patterns of files they don't want to show in
their feed.

Changes:
- Add feedignore_patterns method to Site model to read and parse .feedignore files
- Add should_ignore_from_feed? method to check if files match ignore patterns
- Modify SiteChange model to filter out ignored files from site_change_filenames
- Skip recording changes for ignored files in SiteChange.record

The .feedignore file supports:
- Basic glob patterns (*, ?)
- Comments (lines starting with #)
- One pattern per line
- Empty lines are ignored

resolves #528