### PR TITLE
Add rss to valid editable file extensions

### DIFF
--- a/models/site.rb
+++ b/models/site.rb
@@ -55,7 +55,7 @@ class Site < Sequel::Model
   }
 
   VALID_EDITABLE_EXTENSIONS = %w{
-    html htm txt js css scss md manifest less webmanifest xml json opml rdf svg gpg pgp resolveHandle pls yaml yml toml osdx mjs cjs ts py
+    html htm txt js css scss md manifest less webmanifest xml json opml rdf svg gpg pgp resolveHandle pls yaml yml toml osdx mjs cjs ts py rss
   }
 
   MINIMUM_PASSWORD_LENGTH = 5


### PR DESCRIPTION
# Add RSS to editable file extensions

This PR adds the `.rss` extension to the `VALID_EDITABLE_EXTENSIONS` array, allowing users to edit their RSS files directly through the Neocities web interface. While RSS files are allowed to be hosted on Neocities (`application/rss+xml` in `VALID_MIME_TYPES`), users cannot edit them through the interface and must re-upload them each time they want to make changes.

Since RSS files are already allowed to be hosted, are text-based XML files (which are already editable), and are safe to edit through a web interface, I think this change will improve the user experience with no negative effect on security

Fixes #570