### PR TITLE
Add supporter_status API Route

### DIFF
--- a/app/api.rb
+++ b/app/api.rb
@@ -227,6 +227,12 @@ def api_info_for(site)
   }
 end
 
+get '/api/supporter_status' do
+  require_api_credentials
+
+  api_success supporter: current_site.supporter?
+end
+
 # Catch-all for missing api calls
 
 get '/api/:name' do


### PR DESCRIPTION
# Add API Route for Getting the Current Site's Supporter Status

This PR adds support for sending a `GET` request to `/api/supporter_status` to get whether or not the site currently has supporter features. This API route returns the standard API success alongside the key `supporter` with a boolean value indicating if the site has supporter features or not. This is useful for those creating clients or scripts that interact with the API, as it is otherwise difficult to know which features are available for said tools to use.