### PR TITLE
Fix “ungird” typo

### DIFF
--- a/views/tutorials.erb
+++ b/views/tutorials.erb
@@ -67,7 +67,7 @@
       <a href="https://bulma.io/" title="Bulma: The Framework Built on Flexbox" target="_blank">Bulma</a>
     </li>
     <li>
-      <a href="https://chrisnager.github.io/ungrid/" title="ungrid: the simplest responsive css grid">ungird</a>
+      <a href="https://chrisnager.github.io/ungrid/" title="ungrid: the simplest responsive css grid">ungrid</a>
     </li>
   </ul>
 


### PR DESCRIPTION
There was an *extremely* small typo on the “learn” page, and I fixed it.