### PR TITLE
Require CSRF token for /admin POST routes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -85,6 +85,7 @@ before do
     # Skips the CSRF/validation check for stripe web hooks
   elsif request.path.match /^\/admin/
     require_admin
+    redirect '/' if request.post? && !csrf_safe?
   elsif current_site && current_site.email_not_validated? && !(request.path =~ /^\/site\/.+\/confirm_email|^\/settings\/change_email|^\/welcome|^\/supporter|^\/signout|^\/contact|^\/aup|^\/terms/)
     redirect "/site/#{current_site.username}/confirm_email"
   elsif current_site && current_site.phone_verification_needed? && !(request.path =~ /^\/site\/.+\/confirm_email|^\/settings\/change_email|^\/site\/.+\/confirm_phone|^\/welcome|^\/supporter|^\/signout|^\/aup|^\/terms/)

--- a/tests/acceptance/admin_tests.rb
+++ b/tests/acceptance/admin_tests.rb
@@ -53,6 +53,17 @@ describe '/admin' do
       visit page.driver.response_headers['Location'] if page.driver.response_headers['Location']
       _(page.current_path).must_equal '/', "Signed out user POST should redirect to home page"
     end
+
+    it 'requires csrf token for admin POST routes' do
+      site_to_ban = Fabricate :site
+
+      page.driver.post '/admin/ban', {usernames: site_to_ban.username}
+      _(page.driver.status_code).must_equal 302
+      _(page.driver.response_headers['Location']).must_equal '/'
+
+      site_to_ban.reload
+      _(site_to_ban.is_banned).must_equal false
+    end
   end
 
   describe 'supporter upgrade' do


### PR DESCRIPTION
### Motivation
- A recent change introduced a short-circuit for paths matching `/admin` in the global `before` filter which skipped the global CSRF gate and allowed admin POST endpoints to be invoked without CSRF validation.  
- This patch restores CSRF enforcement for admin POST requests to prevent CSRF attacks against privileged admin actions while keeping admin access control intact.

### Description
- Enforce CSRF validation for admin POST requests by adding `redirect '/' if request.post? && !csrf_safe?` to the `/admin` branch of the global `before` filter in `app.rb`.  
- Add an acceptance test in `tests/acceptance/admin_tests.rb` named `requires csrf token for admin POST routes` which attempts a POST to `/admin/ban` without a CSRF token, asserts a `302` redirect to `/`, and verifies no state change occurred.
- The change is intentionally minimal and scoped to the `/admin` branch so existing behavior and whitelisted POST handling remain unchanged.

### Testing
- Added an acceptance test (`tests/acceptance/admin_tests.rb`) that exercises an admin POST without a CSRF token and asserts redirection and lack of state change.  
- Attempted to run `bundle exec ruby tests/acceptance/admin_tests.rb` in this environment, but it failed due to missing bundled gems (`Bundler::GemNotFound`), so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e85e6e800c83228e313d64cb5073f4)