### PR TITLE
fix profile link visibility

### DIFF
--- a/sass/_project-sass/_project-Website-Gallery.scss
+++ b/sass/_project-sass/_project-Website-Gallery.scss
@@ -26,26 +26,22 @@
   .site-info {
     display: flex;
     flex-wrap: wrap;
+    gap: 0 0.5em;
 
     a, a:visited {
       color: #666;
       font-size: 80%;
     }
     .username {
-      flex: 1;
-      float: left;
-      min-width: 0;
       overflow: hidden;
       text-overflow: ellipsis;
-      width: auto;
       height: 1.3em;
       white-space: nowrap;
     }
     .site-stats {
-      flex: none;
-      float: right;
+      flex: 1;
       overflow: hidden;
-      width: auto;
+      text-overflow: ellipsis;
       text-align: right;
       white-space: nowrap;
     }

--- a/sass/_project-sass/_project-Website-Gallery.scss
+++ b/sass/_project-sass/_project-Website-Gallery.scss
@@ -27,6 +27,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0 0.5em;
+    width: 100%;
 
     a, a:visited {
       color: #666;


### PR DESCRIPTION
Commit 33dc62af57da310f95deb639d23c124c830d028f causes `.username` to shrink to its min-width of 0px on mobile, which hides the links to each site's profile.
This makes `.site-stats` shrink instead, so `.username` stays visible.