### PR TITLE
Add Single File Quick Actions (Copy Code & Download) to Dashboard File Manager

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -3,8 +3,6 @@ var dashboardViewType = localStorage && localStorage.getItem('viewType')
 if(dashboardViewType != 'icon')
   $('#filesDisplay').addClass('list-view')
 
-// Copies text to the user's clipboard using the modern Async Clipboard API,
-// falling back to a hidden textarea + execCommand for older browsers or restricted contexts.
 function copyTextToClipboard(text) {
   if (navigator.clipboard && navigator.clipboard.writeText) {
     return navigator.clipboard.writeText(text);
@@ -14,7 +12,6 @@ function copyTextToClipboard(text) {
     try {
       var textArea = document.createElement('textarea');
       textArea.value = text;
-      // Position off-screen without hiding so execCommand('copy') succeeds reliably
       textArea.style.position = 'fixed';
       textArea.style.top = '-9999px';
       textArea.style.left = '-9999px';
@@ -29,7 +26,7 @@ function copyTextToClipboard(text) {
       if (successful) {
         resolve();
       } else {
-        reject(new Error('execCommand copy was unsuccessful'));
+        reject(new Error('Copy command failed'));
       }
     } catch (err) {
       reject(err);
@@ -37,9 +34,6 @@ function copyTextToClipboard(text) {
   });
 }
 
-// Handles the "Copy Code" quick action for individual text/editable files.
-// Fetches the raw file content from the same-origin download endpoint,
-// writes it to the clipboard, and triggers a smooth feedback transition on the button.
 function copyFileCode(event, path, el) {
   if (event) {
     event.preventDefault();
@@ -49,7 +43,6 @@ function copyFileCode(event, path, el) {
   var $el = $(el);
   var originalHtml = $el.html();
 
-  // Prevent double-clicks while an operation is currently in flight
   if ($el.data('copying')) {
     return;
   }
@@ -58,7 +51,6 @@ function copyFileCode(event, path, el) {
   $el.removeClass('is-copied is-error');
   $el.html('<i class="fa fa-spinner fa-spin"></i> Copying...');
 
-  // URL-encode path segments while preserving directory slashes for Sinatra's wildcard route
   var encodedPath = path.split('/').map(function(segment) {
     return encodeURIComponent(segment);
   }).join('/');

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -3,6 +3,96 @@ var dashboardViewType = localStorage && localStorage.getItem('viewType')
 if(dashboardViewType != 'icon')
   $('#filesDisplay').addClass('list-view')
 
+// Copies text to the user's clipboard using the modern Async Clipboard API,
+// falling back to a hidden textarea + execCommand for older browsers or restricted contexts.
+function copyTextToClipboard(text) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text);
+  }
+
+  return new Promise(function(resolve, reject) {
+    try {
+      var textArea = document.createElement('textarea');
+      textArea.value = text;
+      // Position off-screen without hiding so execCommand('copy') succeeds reliably
+      textArea.style.position = 'fixed';
+      textArea.style.top = '-9999px';
+      textArea.style.left = '-9999px';
+      textArea.setAttribute('readonly', '');
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+
+      var successful = document.execCommand('copy');
+      document.body.removeChild(textArea);
+
+      if (successful) {
+        resolve();
+      } else {
+        reject(new Error('execCommand copy was unsuccessful'));
+      }
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+// Handles the "Copy Code" quick action for individual text/editable files.
+// Fetches the raw file content from the same-origin download endpoint,
+// writes it to the clipboard, and triggers a smooth feedback transition on the button.
+function copyFileCode(event, path, el) {
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  var $el = $(el);
+  var originalHtml = $el.html();
+
+  // Prevent double-clicks while an operation is currently in flight
+  if ($el.data('copying')) {
+    return;
+  }
+
+  $el.data('copying', true);
+  $el.removeClass('is-copied is-error');
+  $el.html('<i class="fa fa-spinner fa-spin"></i> Copying...');
+
+  // URL-encode path segments while preserving directory slashes for Sinatra's wildcard route
+  var encodedPath = path.split('/').map(function(segment) {
+    return encodeURIComponent(segment);
+  }).join('/');
+
+  $.ajax({
+    url: '/site_files/download/' + encodedPath,
+    type: 'GET',
+    dataType: 'text',
+    cache: false,
+    success: function(content) {
+      copyTextToClipboard(content).then(function() {
+        $el.addClass('is-copied').html('<i class="fa fa-check"></i> Copied!');
+        setTimeout(function() {
+          $el.removeClass('is-copied').html(originalHtml);
+          $el.data('copying', false);
+        }, 2000);
+      }).catch(function() {
+        $el.addClass('is-error').html('<i class="fa fa-times"></i> Error');
+        setTimeout(function() {
+          $el.removeClass('is-error').html(originalHtml);
+          $el.data('copying', false);
+        }, 2000);
+      });
+    },
+    error: function() {
+      $el.addClass('is-error').html('<i class="fa fa-times"></i> Error');
+      setTimeout(function() {
+        $el.removeClass('is-error').html(originalHtml);
+        $el.data('copying', false);
+      }, 2000);
+    }
+  });
+}
+
 function confirmFileRename(path) {
   $('#renamePathInput').val(path);
   $('#renameNewPathInput').val(path);

--- a/sass/_project-sass/_project-Main.scss
+++ b/sass/_project-sass/_project-Main.scss
@@ -755,7 +755,6 @@
   display: block;
   padding-top: 35px;
 }
-// File action overlay displayed when hovering over files in the dashboard file manager
 .overlay a {
   color: $c-White;
   text-decoration: none;
@@ -787,7 +786,6 @@
   @include vendor(transform, translateX(1px) scale(0.98));
 }
 
-// Micro-animation for quick action button state changes (Copied / Error)
 @keyframes quickActionPop {
   0% { transform: scale(0.92); opacity: 0.7; }
   50% { transform: scale(1.06); }

--- a/sass/_project-sass/_project-Main.scss
+++ b/sass/_project-sass/_project-Main.scss
@@ -755,16 +755,53 @@
   display: block;
   padding-top: 35px;
 }
+// File action overlay displayed when hovering over files in the dashboard file manager
 .overlay a {
-  color: white;
+  color: $c-White;
   text-decoration: none;
   font-size: 12px;
   display: block;
   margin-left: 5px;
+  line-height: 1.5;
+  @include vendor(transition, color .15s ease, transform .15s ease, text-shadow .15s ease);
+
+  i.fa {
+    width: 14px;
+    text-align: center;
+    margin-right: 3px;
+    @include vendor(transition, transform .15s ease);
+  }
 }
 
 .overlay a:hover {
-  font-size: 14px;
+  color: $c-White;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+  @include vendor(transform, translateX(3px));
+
+  i.fa {
+    @include vendor(transform, scale(1.15));
+  }
+}
+
+.overlay a:active {
+  @include vendor(transform, translateX(1px) scale(0.98));
+}
+
+// Micro-animation for quick action button state changes (Copied / Error)
+@keyframes quickActionPop {
+  0% { transform: scale(0.92); opacity: 0.7; }
+  50% { transform: scale(1.06); }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+.action-copy-code.is-copied {
+  color: #79d799 !important;
+  animation: quickActionPop .2s ease-in-out;
+}
+
+.action-copy-code.is-error {
+  color: #ff7675 !important;
+  animation: quickActionPop .2s ease-in-out;
 }
 
 .overlay .fa-trash, .modal .fa-trash {
@@ -862,9 +899,29 @@
     width: 94%;
 
     a {
-      color: #e93250;
+      color: $c-Brand-1;
       display: inline;
-      margin-right: 5px;
+      margin-right: 8px;
+      font-size: 12px;
+      @include vendor(transition, color .15s ease, transform .15s ease);
+
+      i.fa {
+        margin-right: 3px;
+        @include vendor(transition, transform .15s ease);
+      }
+
+      &:hover {
+        color: $c-Burgundy;
+        text-decoration: none;
+
+        i.fa {
+          @include vendor(transform, translateY(-1px) scale(1.1));
+        }
+      }
+
+      &:active {
+        @include vendor(transform, scale(0.97));
+      }
     }
     .link-overlay {
       width: 30%;

--- a/views/dashboard/files.erb
+++ b/views/dashboard/files.erb
@@ -103,19 +103,16 @@
 
           <div class="overlay">
             <div id="<%= file_dom_id %>" style="display: none"><%= file[:path] %></div>
-            <%# Quick actions for text and code files %>
             <% if file[:is_editable] && !file[:is_directory] %>
               <a href="/site_files/text_editor?filename=<%= Rack::Utils.escape file[:path] %>"><i class="fa fa-edit" title="Edit"></i> Edit</a>
               <a href="javascript:void(0)" class="action-copy-code" onclick="copyFileCode(event, $('#<%= file_dom_id %>').text(), this)"><i class="fa fa-copy" title="Copy Code"></i> Copy Code</a>
             <% end %>
-            <%# Direct download quick action for media and asset files %>
             <% if !file[:is_editable] && !file[:is_directory] %>
               <a href="/site_files/download/<%= Rack::Utils.escape file[:path] %>" download="<%= Rack::Utils.escape_html(file[:name]) %>"><i class="fa fa-download" title="Download"></i> Download</a>
             <% end %>
             <% if file[:is_directory] %>
               <a href="?dir=<%= Rack::Utils.escape file[:path] %>"><i class="fa fa-edit" title="Manage"></i> Manage</a>
             <% end %>
-            <%# Allow rename and delete for any file except the required root index.html %>
             <% if !file[:is_root_index] %>
               <a href="#" onclick="confirmFileRename($('#<%= file_dom_id %>').text())"><i class="fa fa-file" title="Rename"></i> Rename</a>
               <a href="#" onclick="confirmFileDelete($('#<%= file_dom_id %>').text())"><i class="fa fa-trash" title="Delete"></i> Delete</a>

--- a/views/dashboard/files.erb
+++ b/views/dashboard/files.erb
@@ -103,12 +103,19 @@
 
           <div class="overlay">
             <div id="<%= file_dom_id %>" style="display: none"><%= file[:path] %></div>
+            <%# Quick actions for text and code files %>
             <% if file[:is_editable] && !file[:is_directory] %>
               <a href="/site_files/text_editor?filename=<%= Rack::Utils.escape file[:path] %>"><i class="fa fa-edit" title="Edit"></i> Edit</a>
+              <a href="javascript:void(0)" class="action-copy-code" onclick="copyFileCode(event, $('#<%= file_dom_id %>').text(), this)"><i class="fa fa-copy" title="Copy Code"></i> Copy Code</a>
+            <% end %>
+            <%# Direct download quick action for media and asset files %>
+            <% if !file[:is_editable] && !file[:is_directory] %>
+              <a href="/site_files/download/<%= Rack::Utils.escape file[:path] %>" download="<%= Rack::Utils.escape_html(file[:name]) %>"><i class="fa fa-download" title="Download"></i> Download</a>
             <% end %>
             <% if file[:is_directory] %>
               <a href="?dir=<%= Rack::Utils.escape file[:path] %>"><i class="fa fa-edit" title="Manage"></i> Manage</a>
             <% end %>
+            <%# Allow rename and delete for any file except the required root index.html %>
             <% if !file[:is_root_index] %>
               <a href="#" onclick="confirmFileRename($('#<%= file_dom_id %>').text())"><i class="fa fa-file" title="Rename"></i> Rename</a>
               <a href="#" onclick="confirmFileDelete($('#<%= file_dom_id %>').text())"><i class="fa fa-trash" title="Delete"></i> Delete</a>

--- a/views/dashboard/files.erb
+++ b/views/dashboard/files.erb
@@ -108,7 +108,7 @@
               <a href="javascript:void(0)" class="action-copy-code" onclick="copyFileCode(event, $('#<%= file_dom_id %>').text(), this)"><i class="fa fa-copy" title="Copy Code"></i> Copy Code</a>
             <% end %>
             <% if !file[:is_editable] && !file[:is_directory] %>
-              <a href="/site_files/download/<%= Rack::Utils.escape file[:path] %>" download="<%= Rack::Utils.escape_html(file[:name]) %>"><i class="fa fa-download" title="Download"></i> Download</a>
+              <a href="/site_files/download/<%= Site.escape_path file[:path] %>" download="<%= Rack::Utils.escape_html(file[:name]) %>"><i class="fa fa-download" title="Download"></i> Download</a>
             <% end %>
             <% if file[:is_directory] %>
               <a href="?dir=<%= Rack::Utils.escape file[:path] %>"><i class="fa fa-edit" title="Manage"></i> Manage</a>


### PR DESCRIPTION
### Summary
This PR adds quick action buttons for individual files in the dashboard file manager to improve the local development workflow:
- **Copy Code** (`fa-copy`): Instantly fetches and copies the raw code of text-based files (HTML, CSS, JS, Markdown, etc.) to the clipboard without needing to open the in-browser text editor or download a full site archive.
- **Download** (`fa-download`): Provides a direct single-file download for media and binary files (images, audio, video).

### UX & Efficiency Benefits
- **Saves Bandwidth**: Users no longer need to download a full site `.zip` just to retrieve a single stylesheet or asset.
- **Faster Dev Loop**: Seamlessly copy individual file source directly into local IDEs (like VS Code).
- **Native Polish**: Uses native Neocities SCSS vendor mixins, `.15s ease` transitions, spring pop feedback, and preserves root `index.html` protections.

### Verification
- Tested same-origin retrieval and Clipboard API with legacy textarea fallback.
- Tested responsive icon and list views across light and dark themes.
